### PR TITLE
Make FormValue.value setter public

### DIFF
--- a/Formalist/FormValue.swift
+++ b/Formalist/FormValue.swift
@@ -12,7 +12,7 @@ public final class FormValue<ValueType: Equatable> {
     private var observerTokens = [ObserverToken<ValueType>]()
     
     /// The underlying value.
-    internal(set) public var value: ValueType {
+    public var value: ValueType {
         get { return _value }
         set {
             guard _value != newValue else { return }


### PR DESCRIPTION
Has to be public for framework consumers to use it in implementing custom form elements.