### PR TITLE
Remove constant height constraint from ValidationErrorView

### DIFF
--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -69,6 +69,10 @@ public final class GroupElement: FormElement, Validatable {
             static let Thickness: CGFloat = 1.0
         }
         
+        private struct ValidationErrorViewDefaults {
+            static let Height: CGFloat = 30.0
+        }
+        
         /// A block that creates a view to display validation errors
         ///
         /// `message` specifies the message text to display in the view. The default
@@ -97,6 +101,16 @@ public final class GroupElement: FormElement, Validatable {
         public var validationErrorViewFactory: ValidationErrorViewFactory = { message in
             let errorView = ValidationErrorView(frame: CGRectZero)
             errorView.label.text = message
+            let heightConstraint = NSLayoutConstraint(
+                item: errorView,
+                attribute: .Height,
+                relatedBy: .Equal,
+                toItem: nil,
+                attribute: .NotAnAttribute,
+                multiplier: 1.0,
+                constant: ValidationErrorViewDefaults.Height
+            )
+            heightConstraint.active = true
             return errorView
         }
         

--- a/Formalist/ValidationErrorView.swift
+++ b/Formalist/ValidationErrorView.swift
@@ -13,7 +13,6 @@ public class ValidationErrorView: UIView {
     private struct Appearance {
         static let TextColor = UIColor(red: 0.945, green: 0.333, blue: 0.361, alpha: 1.0)
         static let BackgroundColor = UIColor(red: 1.0, green: 0.973, blue: 0.969, alpha: 1.0)
-        static let Height: CGFloat = 30.0
     }
     
     /// The label used to display the message
@@ -40,15 +39,6 @@ public class ValidationErrorView: UIView {
             attribute: .CenterY,
             multiplier: 1.0,
             constant: 0.0
-        ))
-        constraints.append(NSLayoutConstraint(
-            item: self,
-            attribute: .Height,
-            relatedBy: .Equal,
-            toItem: nil,
-            attribute: .NotAnAttribute,
-            multiplier: 1.0,
-            constant: Appearance.Height
         ))
         NSLayoutConstraint.activateConstraints(constraints)
     }

--- a/FormalistTests/ValidationErrorViewTests.swift
+++ b/FormalistTests/ValidationErrorViewTests.swift
@@ -20,6 +20,17 @@ class ValidationErrorViewTests: FBSnapshotTestCase {
         let view = ValidationErrorView(frame: CGRectZero)
         view.label.text = "Error message"
         
+        let heightConstraint = NSLayoutConstraint(
+            item: view,
+            attribute: .Height,
+            relatedBy: .Equal,
+            toItem: nil,
+            attribute: .NotAnAttribute,
+            multiplier: 1.0,
+            constant: 30.0
+        )
+        heightConstraint.active = true
+        
         sizeViewForTesting(view)
         FBSnapshotVerifyView(view)
     }


### PR DESCRIPTION
This is set up in the `validationErrorViewFactory` instead, so that a custom
factory can provide its own constraints.