### PR TITLE
Fix responder chain not working with float labels

### DIFF
--- a/Formalist/FloatLabel.swift
+++ b/Formalist/FloatLabel.swift
@@ -38,6 +38,12 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
     /// a text editing event.
     public var adapterCallbacks: TextEditorAdapterCallbacks<AdapterType>?
     
+    public override var nextFormResponder: UIView? {
+        didSet {
+            textEntryView.nextFormResponder = nextFormResponder
+        }
+    }
+    
     private lazy var labelShownConstraints: [NSLayoutConstraint] = [
         NSLayoutConstraint(item: self.textEntryView, attribute: .Top, relatedBy: .Equal, toItem: self.nameLabel, attribute: .Bottom, multiplier: 1.0, constant: Layout.LabelTextViewSpacing),
         NSLayoutConstraint(item: self.textEntryView, attribute: .Bottom, relatedBy: .Equal, toItem: self, attribute: .Bottom, multiplier: 1.0, constant: 0.0)

--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -184,7 +184,7 @@ public final class GroupElement: FormElement, Validatable {
 
             if elementView.canBecomeFirstResponder() {
                 if let lastResponderView = responderViews.last {
-                    lastResponderView._nextFormResponder = elementView
+                    lastResponderView.nextFormResponder = elementView
                 }
                 responderViews.append(elementView)
             }
@@ -221,7 +221,7 @@ public final class GroupElement: FormElement, Validatable {
         if case let .Grouped(backgroundColor) = configuration.style {
             containerView.backgroundColor = backgroundColor
         }
-        responderViews.last?._nextFormResponder = containerView
+        responderViews.last?.nextFormResponder = containerView
         
         let stackView = UIStackView(arrangedSubviews: subviews)
         stackView.axis = .Vertical

--- a/Formalist/UIView+FormResponder.swift
+++ b/Formalist/UIView+FormResponder.swift
@@ -12,7 +12,13 @@ import ObjectiveC
 private var ObjCNextFormResponderKey: UInt8 = 0
 
 internal extension UIView {
-    var _nextFormResponder: UIView? {
+    /// The next responder in the parent form that this view belongs to.
+    ///
+    /// This is useful for implementing tabbing behaviour between text
+    /// fields, for example. Calling `nextFormResponder?.becomeFirstResponder()`
+    /// from a form view will make the view resign first responder and make
+    /// the next form view the first responder (if it exists).
+    var nextFormResponder: UIView? {
         get {
             if let box = objc_getAssociatedObject(self, &ObjCNextFormResponderKey) as? WeakBox<UIView> {
                 return box.value
@@ -29,17 +35,5 @@ internal extension UIView {
             }
             objc_setAssociatedObject(self, &ObjCNextFormResponderKey, box, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
-    }
-}
-
-public extension UIView {
-    /// The next responder in the parent form that this view belongs to.
-    ///
-    /// This is useful for implementing tabbing behaviour between text
-    /// fields, for example. Calling `nextFormResponder?.becomeFirstResponder()`
-    /// from a form view will make the view resign first responder and make
-    /// the next form view the first responder (if it exists).
-    var nextFormResponder: UIView? {
-        return _nextFormResponder
     }
 }


### PR DESCRIPTION
The `nextFormResponder` of the inner `FloatLabel.textEntryView` was not being set correctly.