### PR TITLE
Resign first responder before executing custom return key action

### DIFF
--- a/Formalist/UITextFieldTextEditorAdapter.swift
+++ b/Formalist/UITextFieldTextEditorAdapter.swift
@@ -121,6 +121,7 @@ private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UIT
             }
             return false
         case let .Custom(action):
+            textField.resignFirstResponder()
             action(textField.text ?? "")
             return false
         }

--- a/Formalist/UITextViewTextEditorAdapter.swift
+++ b/Formalist/UITextViewTextEditorAdapter.swift
@@ -104,6 +104,7 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
                 }
                 return false
             case let .Custom(action):
+                textView.resignFirstResponder()
                 action(textView.text)
                 return false
             }


### PR DESCRIPTION
If `TextEditorConfiguration.continuouslyUpdatesValue` is set to `false` (the default), the form value will not be updated until after the text editor finishes editing. In the case where the return key executed a custom action, the action was being executed *before* the text editor resigned its first responder status, causing the changes to not be committed. This fixes that bug by having the text editor resign first responder before executing the action.