### PR TITLE
Two-way bindings

### DIFF
--- a/Formalist.xcodeproj/project.pbxproj
+++ b/Formalist.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		72239FEB1D25B9E800A157D9 /* UIView+ChangeObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72239FEA1D25B9E800A157D9 /* UIView+ChangeObservation.swift */; };
 		7285A70A1D17CB7000718D23 /* Formalist.h in Headers */ = {isa = PBXBuildFile; fileRef = 7285A7091D17CB7000718D23 /* Formalist.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7285A7111D17CB7000718D23 /* Formalist.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7285A7061D17CB7000718D23 /* Formalist.framework */; };
 		7285A73D1D17CBCA00718D23 /* BooleanElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7285A7201D17CBCA00718D23 /* BooleanElement.swift */; };
@@ -165,6 +166,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		72239FEA1D25B9E800A157D9 /* UIView+ChangeObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+ChangeObservation.swift"; sourceTree = "<group>"; };
 		7285A7061D17CB7000718D23 /* Formalist.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Formalist.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7285A7091D17CB7000718D23 /* Formalist.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Formalist.h; sourceTree = "<group>"; };
 		7285A70B1D17CB7000718D23 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -455,6 +457,7 @@
 				7285A7381D17CBCA00718D23 /* Validatable.swift */,
 				7285A73A1D17CBCA00718D23 /* ValidationRule.swift */,
 				7285A7371D17CBCA00718D23 /* UIView+FormResponder.swift */,
+				72239FEA1D25B9E800A157D9 /* UIView+ChangeObservation.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -717,6 +720,7 @@
 				7285A74B1D17CBCA00718D23 /* SegmentElementView.swift in Sources */,
 				7285A7541D17CBCA00718D23 /* UIView+FormResponder.swift in Sources */,
 				7285A74D1D17CBCA00718D23 /* SegueElementView.swift in Sources */,
+				72239FEB1D25B9E800A157D9 /* UIView+ChangeObservation.swift in Sources */,
 				7285A7421D17CBCA00718D23 /* FloatLabel.swift in Sources */,
 				7285A7511D17CBCA00718D23 /* TextEditorConfiguration.swift in Sources */,
 				7285A74F1D17CBCA00718D23 /* StaticTextElement.swift in Sources */,

--- a/Formalist/BooleanElement.swift
+++ b/Formalist/BooleanElement.swift
@@ -33,17 +33,27 @@ public final class BooleanElement: FormElement {
     }
     
     public func render() -> UIView {
-        let booleanView = BooleanElementView(title: title, value: value.value)
+        let booleanView = BooleanElementView(title: title)
         booleanView.toggle.addTarget(
             self,
             action: #selector(BooleanElement.valueChanged(_:)),
             forControlEvents: .ValueChanged
         )
+        let updateView: Bool -> Void = { [weak booleanView] in
+            guard let booleanView = booleanView else { return }
+            if !booleanView.shouldIgnoreFormValueChanges {
+                booleanView.toggle.on = $0
+            }
+        }
+        updateView(value.value)
+        value.addObserver(updateView)
         viewConfigurator?(booleanView)
         return booleanView
     }
     
     @objc private func valueChanged(sender: UISwitch) {
+        sender.shouldIgnoreFormValueChanges = true
         value.value = sender.on
+        sender.shouldIgnoreFormValueChanges = false
     }
 }

--- a/Formalist/BooleanElementView.swift
+++ b/Formalist/BooleanElementView.swift
@@ -21,14 +21,13 @@ public class BooleanElementView: UIView {
     /// The toggle used to change the boolean value
     public let toggle: UISwitch
     
-    init(title: String, value: Bool = false) {
+    init(title: String) {
         titleLabel = UILabel(frame: CGRectZero)
         titleLabel.font = UIFont.preferredFontForTextStyle(UIFontTextStyleBody)
         titleLabel.text = title
         titleLabel.setContentHuggingPriority(UILayoutPriorityDefaultLow, forAxis: .Horizontal)
         
         toggle = UISwitch(frame: CGRectZero)
-        toggle.on = value
         
         super.init(frame: CGRectZero)
         

--- a/Formalist/Convenience.swift
+++ b/Formalist/Convenience.swift
@@ -62,6 +62,20 @@ public func staticText(text: String, viewConfigurator: StaticTextElement.ViewCon
 }
 
 /**
+ Creates a form element that displays static text.
+ Convenience function for initializing a `StaticTextElement`
+ 
+ - parameter value:            The text value to bind to the label
+ - parameter viewConfigurator: An optional block used to configure the appearance
+ of the view
+ 
+ - returns: A static text form element
+ */
+public func staticText(value: FormValue<String>, viewConfigurator: StaticTextElement.ViewConfigurator? = nil) -> StaticTextElement {
+    return StaticTextElement(value: value, viewConfigurator: viewConfigurator)
+}
+
+/**
  Creates a form element that displays a cell that invokes an action when tapped
  Convenience function for initializing a `SegueElement`
  

--- a/Formalist/FormValue.swift
+++ b/Formalist/FormValue.swift
@@ -70,7 +70,7 @@ public final class FormValue<ValueType: Equatable> {
 
 /// A token that represents an observer. This is returned from `FormValue.addObserver(_:)`
 /// and passed into `FormValue.removeObserverWithToken(_:)`
-public class ObserverToken<ValueType>: Equatable {
+public final class ObserverToken<ValueType>: Equatable {
     private typealias Observer = ValueType -> Void
     private let observer: Observer
     

--- a/Formalist/SegmentElement.swift
+++ b/Formalist/SegmentElement.swift
@@ -38,16 +38,15 @@ public final class SegmentElement<ValueType: Equatable>: FormElement {
     }
     
     public func render() -> UIView {
-        let items = self.segments.map { $0.content }
+        let items = segments.map { $0.content }
         let segmentView = SegmentElementView(title: title, items: items)
         segmentView.segmentedControl.addTarget(
             self,
             action: #selector(SegmentElement.selectedSegmentChanged(_:)),
             forControlEvents: .ValueChanged
         )
-        let segments = self.segments
-        let updateView: ValueType -> Void = { [weak segmentView] selectedValue in
-            guard let segmentView = segmentView else { return }
+        let updateView: ValueType -> Void = { [weak segmentView, weak self] selectedValue in
+            guard let segmentView = segmentView, segments = self?.segments else { return }
             if !segmentView.shouldIgnoreFormValueChanges {
                 segmentView.segmentedControl.selectedSegmentIndex = {
                     for (index, value) in segments.map({ $0.value }).enumerate() {

--- a/Formalist/SegmentElement.swift
+++ b/Formalist/SegmentElement.swift
@@ -38,25 +38,29 @@ public final class SegmentElement<ValueType: Equatable>: FormElement {
     }
     
     public func render() -> UIView {
-        let items = segments.map { $0.content }
-        let selectedIndex: Int = {
-            for (index, value) in segments.map({ $0.value }).enumerate() {
-                if (value == selectedValue.value) {
-                    return index
-                }
-            }
-            fatalError("\(selectedValue) does not exist in \(segments)")
-        }()
-        let segmentView = SegmentElementView(
-            title: title,
-            items: items,
-            selectedIndex: selectedIndex
-        )
+        let items = self.segments.map { $0.content }
+        let segmentView = SegmentElementView(title: title, items: items)
         segmentView.segmentedControl.addTarget(
             self,
             action: #selector(SegmentElement.selectedSegmentChanged(_:)),
             forControlEvents: .ValueChanged
         )
+        let segments = self.segments
+        let updateView: ValueType -> Void = { [weak segmentView] selectedValue in
+            guard let segmentView = segmentView else { return }
+            if !segmentView.shouldIgnoreFormValueChanges {
+                segmentView.segmentedControl.selectedSegmentIndex = {
+                    for (index, value) in segments.map({ $0.value }).enumerate() {
+                        if (value == selectedValue) {
+                            return index
+                        }
+                    }
+                    fatalError("\(selectedValue) does not exist in \(segments)")
+                }()
+            }
+        }
+        updateView(selectedValue.value)
+        selectedValue.addObserver(updateView)
         viewConfigurator?(segmentView)
         return segmentView
     }

--- a/Formalist/SegmentElementView.swift
+++ b/Formalist/SegmentElementView.swift
@@ -21,13 +21,12 @@ public class SegmentElementView: UIView {
     /// The segmented control that displays the segments
     public let segmentedControl: UISegmentedControl
     
-    init(title: String, items: [SegmentContent], selectedIndex: Int) {
+    init(title: String, items: [SegmentContent]) {
         titleLabel = UILabel(frame: CGRectZero)
         titleLabel.font = UIFont.preferredFontForTextStyle(UIFontTextStyleSubheadline)
         titleLabel.text = title
         
         segmentedControl = UISegmentedControl(items: items.map { $0.objectValue })
-        segmentedControl.selectedSegmentIndex = selectedIndex
         
         super.init(frame: CGRectZero)
         

--- a/Formalist/StaticTextElement.swift
+++ b/Formalist/StaticTextElement.swift
@@ -12,21 +12,35 @@ import UIKit
 public final class StaticTextElement: FormElement {
     public typealias ViewConfigurator = UILabel -> Void
     
-    private let text: String
+    private let value: FormValue<String>
     private let viewConfigurator: ViewConfigurator?
     
     /**
      Designated initializer
      
-     - parameter text:             The text to display
+     - parameter value:            The text value to bind to the label
      - parameter viewConfigurator: An optional block used to configure the label
      used to display the text
      
      - returns: An initialized instance of the receiver
      */
-    public init(text: String, viewConfigurator: ViewConfigurator? = nil) {
-        self.text = text
+    public init(value: FormValue<String>, viewConfigurator: ViewConfigurator? = nil) {
+        self.value = value
         self.viewConfigurator = viewConfigurator
+    }
+    
+    /**
+     Convenience initializer to initialize using a `String` rather than a
+     `FormValue`.
+     
+     - parameter text:             The text to display in the label
+     - parameter viewConfigurator: An optional block used to configure the label
+     used to display the text
+     
+     - returns: An initialized instance of the receiver
+     */
+    public convenience init(text: String, viewConfigurator: ViewConfigurator? = nil) {
+        self.init(value: FormValue(text), viewConfigurator: viewConfigurator)
     }
     
     public func render() -> UIView {
@@ -34,7 +48,10 @@ public final class StaticTextElement: FormElement {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         label.font = UIFont.preferredFontForTextStyle(UIFontTextStyleBody)
-        label.text = text
+        label.text = value.value
+        value.addObserver { [weak label] in
+            label?.text = $0
+        }
         viewConfigurator?(label)
         return label
     }

--- a/Formalist/TextEditorAdapter.swift
+++ b/Formalist/TextEditorAdapter.swift
@@ -61,6 +61,10 @@ public protocol TextEditorAdapter: AnyObject {
     func setText(text: String, forView view: ViewType)
 }
 
+public extension TextEditorAdapter {
+    public typealias TextChangedObserver = (Self, ViewType) -> Void
+}
+
 /// Contains callback functions that are executed when a text editing
 /// event occurs.
 public struct TextEditorAdapterCallbacks<AdapterType: TextEditorAdapter> {
@@ -75,7 +79,3 @@ public struct TextEditorAdapterCallbacks<AdapterType: TextEditorAdapter> {
     /// Called when any change is made to the text
     public var textDidChange: Callback?
 }
-
-/// Type definition for a block that is called with a `String` argument when
-/// text in a text editing view has changed.
-public typealias TextChangedObserver = String -> Void

--- a/Formalist/UITextFieldTextEditorAdapter.swift
+++ b/Formalist/UITextFieldTextEditorAdapter.swift
@@ -12,6 +12,7 @@ import UIKit
 /// form elements that perform text editing.
 public final class UITextFieldTextEditorAdapter<TextFieldType: UITextField>: TextEditorAdapter {
     public typealias ViewType = TextFieldType
+    public typealias TextChangedObserver = (UITextFieldTextEditorAdapter<ViewType>, ViewType) -> Void
     
     private let configuration: TextEditorConfiguration
     
@@ -48,6 +49,7 @@ private var ObjCTextFieldDelegateKey: UInt8 = 0
 
 private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UITextFieldDelegate {
     private typealias AdapterType = UITextFieldTextEditorAdapter<TextFieldType>
+    private typealias TextChangedObserver = (AdapterType, TextFieldType) -> Void
     
     private let adapter: AdapterType
     private let configuration: TextEditorConfiguration
@@ -89,7 +91,7 @@ private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UIT
         }
         callbacks.textDidEndEditing?(adapter, textField)
         if !configuration.continuouslyUpdatesValue {
-            textChangedObserver(textField.text ?? "")
+            textChangedObserver(adapter, textField)
         }
     }
     
@@ -99,8 +101,12 @@ private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UIT
         }
         callbacks.textDidChange?(adapter, textField)
         if configuration.continuouslyUpdatesValue {
-            textChangedObserver(textField.text ?? "")
+            textChangedObserver(adapter, textField)
         }
+    }
+    
+    private func notifyTextChangedObserverWithTextField(textField: UITextField) {
+        textField.shouldIgnoreFormValueChanges = true
     }
     
     @objc private func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {

--- a/Formalist/UITextViewTextEditorAdapter.swift
+++ b/Formalist/UITextViewTextEditorAdapter.swift
@@ -13,6 +13,7 @@ import ObjectiveC
 /// form elements that perform text editing.
 public final class UITextViewTextEditorAdapter<TextViewType: UITextView>: TextEditorAdapter {
     public typealias ViewType = TextViewType
+    public typealias TextChangedObserver = (UITextViewTextEditorAdapter<ViewType>, ViewType) -> Void
     
     private let configuration: TextEditorConfiguration
     
@@ -51,6 +52,7 @@ private var ObjCTextViewDelegateKey: UInt8 = 0
 
 private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UITextViewDelegate {
     private typealias AdapterType = UITextViewTextEditorAdapter<TextViewType>
+    private typealias TextChangedObserver = (AdapterType, TextViewType) -> Void
     
     private let adapter: AdapterType
     private let configuration: TextEditorConfiguration
@@ -79,7 +81,7 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
         }
         callbacks.textDidEndEditing?(adapter, textView)
         if !configuration.continuouslyUpdatesValue {
-            textChangedObserver(textView.text)
+            textChangedObserver(adapter, textView)
         }
     }
     
@@ -89,7 +91,7 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
         }
         callbacks.textDidChange?(adapter, textView)
         if configuration.continuouslyUpdatesValue {
-            textChangedObserver(textView.text)
+            textChangedObserver(adapter, textView)
         }
     }
     

--- a/Formalist/UIView+ChangeObservation.swift
+++ b/Formalist/UIView+ChangeObservation.swift
@@ -1,0 +1,29 @@
+//
+//  UIView+ChangeObservation.swift
+//  Formalist
+//
+//  Created by Indragie Karunaratne on 2016-06-30.
+//  Copyright © 2016 Seed Platform, Inc. All rights reserved.
+//
+
+import UIKit
+
+private var ObjCShouldIgnoreFormValueChangesKey: UInt8 = 0
+
+public extension UIView {
+    /// This flag is set inside `FormElement` implementations in order to break
+    /// a potential infinite loop when `FormValue.value` is set while there is
+    /// an observer on that value that updates the value on the view.
+    public var shouldIgnoreFormValueChanges: Bool {
+        get {
+            if let box = objc_getAssociatedObject(self, &ObjCShouldIgnoreFormValueChangesKey) as? Box<Bool> {
+                return box.value
+            } else {
+                return false
+            }
+        }
+        set {
+            objc_setAssociatedObject(self, &ObjCShouldIgnoreFormValueChangesKey, Box(newValue), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+}

--- a/FormalistTests/BooleanElementTests.swift
+++ b/FormalistTests/BooleanElementTests.swift
@@ -21,4 +21,12 @@ class BooleanElementTests: FBSnapshotTestCase {
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
     }
+    
+    func testUpdateViewByUpdatingValue() {
+        let value = FormValue(false)
+        let element = BooleanElement(title: "Test Boolean Element", value: value)
+        let elementView = element.render() as! BooleanElementView
+        value.value = true
+        XCTAssertTrue(elementView.toggle.on)
+    }
 }

--- a/FormalistTests/EditableTextElementTests.swift
+++ b/FormalistTests/EditableTextElementTests.swift
@@ -57,4 +57,40 @@ class EditableTextElementTests: FBSnapshotTestCase {
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
     }
+    
+    func testUpdateTextFieldByUpdatingValue() {
+        let value = FormValue("foo")
+        let element = textField(value: value)
+        let elementView = element.render() as! UITextField
+        
+        value.value = "bar"
+        XCTAssertEqual("bar", elementView.text)
+    }
+    
+    func testUpdateTextViewByUpdatingValue() {
+        let value = FormValue("foo")
+        let element = textView(value: value)
+        let elementView = element.render() as! UITextView
+        
+        value.value = "bar"
+        XCTAssertEqual("bar", elementView.text)
+    }
+    
+    func testUpdateSingleLineFloatLabelByUpdatingValue() {
+        let value = FormValue("foo")
+        let element = singleLineFloatLabel(name: "Float Label", value: value)
+        let elementView = element.render() as! FloatLabel<UITextFieldTextEditorAdapter<FloatLabelTextField>>
+        
+        value.value = "bar"
+        XCTAssertEqual("bar", elementView.textEntryView.text)
+    }
+    
+    func testUpdateMultiLineFloatLabelByUpdatingValue() {
+        let value = FormValue("foo")
+        let element = multiLineFloatLabel(name: "Float Label", value: value)
+        let elementView = element.render() as! FloatLabel<UITextViewTextEditorAdapter<PlaceholderTextView>>
+        
+        value.value = "bar"
+        XCTAssertEqual("bar", elementView.textEntryView.text)
+    }
 }

--- a/FormalistTests/FloatLabelTests.swift
+++ b/FormalistTests/FloatLabelTests.swift
@@ -18,7 +18,7 @@ class FloatLabelTests: FBSnapshotTestCase {
         recordMode = false
         
         let adapter = UITextFieldTextEditorAdapter<FloatLabelTextField>(configuration: TextEditorConfiguration())
-        floatLabel = FloatLabel(adapter: adapter, textChangedObserver: { _ in })
+        floatLabel = FloatLabel(adapter: adapter)
         floatLabel.setFieldName("Test")
     }
     
@@ -43,7 +43,7 @@ class FloatLabelTests: FBSnapshotTestCase {
     
     func testRenderWithMultiLineTextAndLabelShown() {
         let adapter = UITextViewTextEditorAdapter<PlaceholderTextView>(configuration: TextEditorConfiguration())
-        let floatLabel = FloatLabel(adapter: adapter, textChangedObserver: { _ in})
+        let floatLabel = FloatLabel(adapter: adapter)
         floatLabel.textEntryView.text = "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Nulla vitae elit libero, a pharetra augue."
         floatLabel.transitionToState(.LabelShown, animated: false)
         sizeViewForTesting(floatLabel)

--- a/FormalistTests/SegmentElementTests.swift
+++ b/FormalistTests/SegmentElementTests.swift
@@ -16,12 +16,13 @@ class SegmentElementTests: FBSnapshotTestCase {
         recordMode = false
     }
     
-    private func segmentElementWithSelectedIndex(index: Int) -> SegmentElement<Int> {
+    private func segmentElementWithSelectedIndex(index: Int, value: FormValue<Int> = FormValue(0)) -> SegmentElement<Int> {
         let segments = [
             Segment(content: .Title("Segment 1"), value: 0),
             Segment(content: .Image(imageWithName("circle")), value: 1)
         ]
-        let element = SegmentElement(title: "Segment Element", segments: segments, selectedValue: FormValue(index)) {
+        value.value = index
+        let element = SegmentElement(title: "Segment Element", segments: segments, selectedValue: value) {
             $0.titleLabel.textAlignment = .Center
             $0.titleLabel.textColor = .redColor()
             $0.segmentedControl.tintColor = .greenColor()
@@ -39,5 +40,13 @@ class SegmentElementTests: FBSnapshotTestCase {
         let element = segmentElementWithSelectedIndex(1)
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
+    }
+    
+    func testUpdateViewByUpdatingValue() {
+        let value = FormValue(0)
+        let element = segmentElementWithSelectedIndex(0, value: value)
+        let elementView = element.render() as! SegmentElementView
+        value.value = 1
+        XCTAssertEqual(1, elementView.segmentedControl.selectedSegmentIndex)
     }
 }

--- a/FormalistTests/StaticTextElementTests.swift
+++ b/FormalistTests/StaticTextElementTests.swift
@@ -17,11 +17,20 @@ class StaticTextElementTests: FBSnapshotTestCase {
     }
     
     func testRender() {
-        let element = StaticTextElement(text: "Static Text Element") {
+        let element = staticText("Static Text Element") {
             $0.textAlignment = .Center
             $0.textColor = .redColor()
         }
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
+    }
+    
+    func testUpdateViewByUpdatingValue() {
+        let value = FormValue("foo")
+        let element = staticText(value)
+        let elementView = element.render() as! UILabel
+        
+        value.value = "bar"
+        XCTAssertEqual("bar", elementView.text)
     }
 }


### PR DESCRIPTION
Currently, bindings between `FormElement`'s and `FormValue`'s are only one-way: a user updating the value of a form element causes the `FormValue` its bound to to be updated, but updating `FormValue.value` directly doesn't cause the form element's view to be updated accordingly. This PR implements bidirectional bindings for all elements that could benefit from it (`BooleanElement`, `SegmentElement`, `EditableTextElement`, and `StaticTextElement`).