### PR TITLE
Textfield padding

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: UIViewController {
     private let booleanValue = FormValue(false)
     private let textViewValue = FormValue("")
     private let floatLabelValue = FormValue("")
+    private let multiLineFloatLabelValue = FormValue("")
     private let emailValue = FormValue("")
     private let stringValue3 = FormValue("")
     
@@ -50,6 +51,9 @@ class ViewController: UIViewController {
                 },
                 singleLineFloatLabel(name: "Float Label Element", value: self.floatLabelValue) {
                     $0.textEntryView.accessibilityIdentifier = "floatLabel"
+                },
+                multiLineFloatLabel(name: "Float MultiLine Element", value: self.multiLineFloatLabelValue) {
+                    $0.textEntryView.accessibilityIdentifier = "multiLineFloatLabel"
                 },
                 segments(title: "Segment Element", segments: [
                     Segment(content: .Title("Segment 1"), value: "Segment 1"),

--- a/Formalist/FloatLabel.swift
+++ b/Formalist/FloatLabel.swift
@@ -31,6 +31,7 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
         return nameLabel
     }()
     
+    /// The container view used for adding spacing to textEntryView.
     public let containerView: UIView =  {
         let containerView = UIView()
         return containerView
@@ -57,7 +58,7 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
     public var textChangedObserver: TextChangedObserver?
     
     private lazy var labelShownConstraints: [NSLayoutConstraint] = [
-        NSLayoutConstraint(item: self.containerView, attribute: .Top, relatedBy: .Equal, toItem: self.nameLabel, attribute: .Bottom, multiplier: 1.0, constant: Layout.LabelTextViewSpacing),
+        NSLayoutConstraint(item: self.containerView, attribute: .Top, relatedBy: .Equal, toItem: self.nameLabel, attribute: .Bottom, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.containerView, attribute: .Bottom, relatedBy: .LessThanOrEqual, toItem: self, attribute: .Bottom, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.containerView, attribute: .Height, relatedBy: .GreaterThanOrEqual, toItem: self.textEntryView, attribute: .Height, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.textEntryView, attribute: .Top, relatedBy: .Equal, toItem: self.containerView, attribute: .Top, multiplier: 1.0, constant: Layout.InnerTextInputTopSpacing),
@@ -70,7 +71,8 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
         NSLayoutConstraint(item: self.containerView, attribute: .Bottom, relatedBy: .LessThanOrEqual, toItem: self, attribute: .Bottom, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.containerView, attribute: .Height, relatedBy: .GreaterThanOrEqual, toItem: self.textEntryView, attribute: .Height, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.textEntryView, attribute: .Top, relatedBy: .Equal, toItem: self.containerView, attribute: .Top, multiplier: 1.0, constant: Layout.InnerTextInputTopSpacing),
-        NSLayoutConstraint(item: self.textEntryView, attribute: .Bottom, relatedBy: .Equal, toItem: self.containerView, attribute: .Bottom, multiplier: 1.0, constant: Layout.InnerTextInputBottomSpacing)
+        NSLayoutConstraint(item: self.textEntryView, attribute: .Bottom, relatedBy: .Equal, toItem: self.containerView, attribute: .Bottom, multiplier: 1.0, constant: Layout.InnerTextInputBottomSpacing),
+        NSLayoutConstraint(item: self.textEntryView, attribute: .CenterY, relatedBy: .Equal, toItem: self.containerView, attribute: .CenterY, multiplier: 1.0, constant: 0.0)
     ]
     
     private lazy var heightConstraint: NSLayoutConstraint = NSLayoutConstraint(item: self, attribute: .Height, relatedBy: .GreaterThanOrEqual, toItem: nil, attribute: .NotAnAttribute, multiplier: 1.0, constant: 0.0)
@@ -253,9 +255,8 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
 }
 
 private struct Layout {
-    static let LabelTextViewSpacing: CGFloat = 4.0
-    static let InnerTextInputTopSpacing: CGFloat = 12
-    static let InnerTextInputBottomSpacing: CGFloat = -12
+    static let InnerTextInputTopSpacing: CGFloat = 10
+    static let InnerTextInputBottomSpacing: CGFloat = -10
 }
 
 enum State {

--- a/Formalist/FloatLabel.swift
+++ b/Formalist/FloatLabel.swift
@@ -58,11 +58,11 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
     public var textChangedObserver: TextChangedObserver?
     
     private lazy var labelShownConstraints: [NSLayoutConstraint] = [
-        NSLayoutConstraint(item: self.containerView, attribute: .Top, relatedBy: .Equal, toItem: self.nameLabel, attribute: .Bottom, multiplier: 1.0, constant: 0.0),
+        NSLayoutConstraint(item: self.containerView, attribute: .Top, relatedBy: .Equal, toItem: self, attribute: .Top, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.containerView, attribute: .Bottom, relatedBy: .LessThanOrEqual, toItem: self, attribute: .Bottom, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.containerView, attribute: .Height, relatedBy: .GreaterThanOrEqual, toItem: self.textEntryView, attribute: .Height, multiplier: 1.0, constant: 0.0),
-        NSLayoutConstraint(item: self.textEntryView, attribute: .Top, relatedBy: .Equal, toItem: self.containerView, attribute: .Top, multiplier: 1.0, constant: Layout.InnerTextInputTopSpacing),
-        NSLayoutConstraint(item: self.textEntryView, attribute: .Bottom, relatedBy: .Equal, toItem: self.containerView, attribute: .Bottom, multiplier: 1.0, constant: Layout.InnerTextInputBottomSpacing)
+        NSLayoutConstraint(item: self.textEntryView, attribute: .Top, relatedBy: .Equal, toItem: self.containerView, attribute: .Top, multiplier: 1.0, constant: Layout.TextInputTopSpacing + Layout.TextInputTopShownSpacing),
+        NSLayoutConstraint(item: self.textEntryView, attribute: .Bottom, relatedBy: .Equal, toItem: self.containerView, attribute: .Bottom, multiplier: 1.0, constant: Layout.TextInputBottomSpacing)
     ]
     
     private lazy var labelHiddenConstraints: [NSLayoutConstraint] = [
@@ -70,8 +70,8 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
         NSLayoutConstraint(item: self.containerView, attribute: .Top, relatedBy: .GreaterThanOrEqual, toItem: self, attribute: .Top, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.containerView, attribute: .Bottom, relatedBy: .LessThanOrEqual, toItem: self, attribute: .Bottom, multiplier: 1.0, constant: 0.0),
         NSLayoutConstraint(item: self.containerView, attribute: .Height, relatedBy: .GreaterThanOrEqual, toItem: self.textEntryView, attribute: .Height, multiplier: 1.0, constant: 0.0),
-        NSLayoutConstraint(item: self.textEntryView, attribute: .Top, relatedBy: .Equal, toItem: self.containerView, attribute: .Top, multiplier: 1.0, constant: Layout.InnerTextInputTopSpacing),
-        NSLayoutConstraint(item: self.textEntryView, attribute: .Bottom, relatedBy: .Equal, toItem: self.containerView, attribute: .Bottom, multiplier: 1.0, constant: Layout.InnerTextInputBottomSpacing),
+        NSLayoutConstraint(item: self.textEntryView, attribute: .Top, relatedBy: .Equal, toItem: self.containerView, attribute: .Top, multiplier: 1.0, constant: Layout.TextInputTopSpacing),
+        NSLayoutConstraint(item: self.textEntryView, attribute: .Bottom, relatedBy: .Equal, toItem: self.containerView, attribute: .Bottom, multiplier: 1.0, constant: Layout.TextInputBottomSpacing),
         NSLayoutConstraint(item: self.textEntryView, attribute: .CenterY, relatedBy: .Equal, toItem: self.containerView, attribute: .CenterY, multiplier: 1.0, constant: 0.0)
     ]
     
@@ -93,7 +93,7 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
         textEntryView = createTextEntryView()
         textEntryView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerView)
-        addSubview(nameLabel)
+        containerView.addSubview(nameLabel)
         containerView.addSubview(textEntryView)
         
         setupConstraints()
@@ -144,7 +144,7 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
         let bodyTextViewHConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[textEntryView]|", options: [], metrics: nil, views: views)
         NSLayoutConstraint.activateConstraints(bodyTextViewHConstraints)
         
-        let nameLabelTopConstraint = NSLayoutConstraint(item: nameLabel, attribute: .Top, relatedBy: .Equal, toItem: self, attribute: .Top, multiplier: 1.0, constant: 0.0)
+        let nameLabelTopConstraint = NSLayoutConstraint(item: nameLabel, attribute: .Top, relatedBy: .Equal, toItem: containerView, attribute: .Top, multiplier: 1.0, constant: 0.0)
         nameLabelTopConstraint.active = true
     }
     
@@ -255,8 +255,10 @@ public class FloatLabel<AdapterType: TextEditorAdapter where AdapterType.ViewTyp
 }
 
 private struct Layout {
-    static let InnerTextInputTopSpacing: CGFloat = 10
-    static let InnerTextInputBottomSpacing: CGFloat = -10
+    static let TextInputTopSpacing: CGFloat = 12
+    static let TextInputTopShownSpacing: CGFloat = 8
+    static let TopSpacing: CGFloat = 16
+    static let TextInputBottomSpacing: CGFloat = -12
 }
 
 enum State {


### PR DESCRIPTION
Added container view for Float Label that allows us to add 12px from the top and bottom. So clickable area become => 44px 

Added `multiLineFloatLabel` to example View Controller

<img width="836" alt="screenshot 2016-07-18 11 52 40" src="https://cloud.githubusercontent.com/assets/1641795/16926598/3f9bc312-4cde-11e6-8d4c-70c2b52484e1.png">

<img width="333" alt="screenshot 2016-07-18 11 55 16" src="https://cloud.githubusercontent.com/assets/1641795/16926655/825e4cba-4cde-11e6-94a3-c1a3b9a5fa92.png">

<img width="333" alt="screenshot 2016-07-18 11 52 11" src="https://cloud.githubusercontent.com/assets/1641795/16926597/3f9b96a8-4cde-11e6-8555-ea2ec5307dfc.png">