### PR TITLE
Make GroupElement#elements public

### DIFF
--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -150,7 +150,11 @@ public final class GroupElement: FormElement, Validatable {
     }
     
     private let configuration: Configuration
-    private let elements: [FormElement]
+
+    /**
+     The elements that make up the group.
+    */
+    public let elements: [FormElement]
     
     /**
      Designated initializer


### PR DESCRIPTION
This is useful for verifying the state of a `GroupElement`. In a test
for example.