### PR TITLE
Restore original color when not showing placeholder

### DIFF
--- a/Formalist/PlaceholderTextView.swift
+++ b/Formalist/PlaceholderTextView.swift
@@ -104,7 +104,7 @@ public class PlaceholderTextView: UITextView {
         didSet { showPlaceholder = !editing && text.isEmpty }
     }
     
-    private var _showPlaceholder: Bool = true
+    private var _showPlaceholder: Bool = false
     private var showPlaceholder: Bool {
         get { return _showPlaceholder }
         set {
@@ -119,6 +119,7 @@ public class PlaceholderTextView: UITextView {
                 originalTextAttributes = defaultTextAttributes
                 super.attributedText = attributedPlaceholder
             } else {
+                super.textColor = originalTextAttributes?[NSForegroundColorAttributeName] as? UIColor
                 super.attributedText = NSAttributedString(string: "", attributes: originalTextAttributes ?? [:])
                 originalTextAttributes = nil
             }
@@ -183,6 +184,8 @@ public class PlaceholderTextView: UITextView {
         let nc = NSNotificationCenter.defaultCenter()
         nc.addObserver(self, selector: #selector(PlaceholderTextView.textDidBeginEditing(_:)), name: UITextViewTextDidBeginEditingNotification, object: self)
         nc.addObserver(self, selector: #selector(PlaceholderTextView.textDidEndEditing(_:)), name: UITextViewTextDidEndEditingNotification, object: self)
+
+        showPlaceholder = true
     }
     
     deinit {


### PR DESCRIPTION
`PlaceholderTextView` never restore the original `textColor` after
displaying a placeholder. To understand this issue it's important to
understand that the view can be in two states: 1) Placeholder and 2)
Normal.

When the view is initialized it is in the Placeholder state. Normally
when it transitions into the placeholder state it sets
`originalTextAttributes`. However because `showPlaceholder=` is never
called during initialization `originalTextAttributes` is never set.

This is a problem because when `textColor=` is called, it correctly
detects that it's in the Placeholder state so assigns the new textcolor
to `originalTextAttributes?[NSForegroundColorAttributeName]`. Because
`originalTextAttributes` is `.None` at this point, we never keep track
of the `textColor` that we want.

The main issue here is that when the view is initialized there is no
text so it's in the Placeholder state. To ensure this is actually true
we call `showPlaceholder = true` during initialization. This also
correctly sets up the `originalTextAttributes` to keep track of any
changes we make to the Normal state.

The second problem is caused by how `UITextView` behaves. When
`super.attributedText` is set by `showPlaceholder` that also changes the
value of `super.textColor` to the placeholder text color. This is a
problem because `defaultTextAttributes` uses the `super.textColor`.

So when `text` is called and we enter the Normal state
`defaultTextAttributes` inadvertently returns the placeholder text
color. The fix here is to make sure that when we restore the
`originalTextAttributes` in `showPlaceholder` we also restore the
text color by calling `super.textColor =
originalTextAttributes[NSForegroundColorAttributeName]`.

These two fixes combined mean that we now correctly show `textColor` in
the Normal state and `placeholderColor` in the Placeholder state.