### PR TITLE
Allow customizing the spacing between a title and segmented control

### DIFF
--- a/Formalist/SegmentElementView.swift
+++ b/Formalist/SegmentElementView.swift
@@ -11,8 +11,12 @@ import StackViewController
 
 /// The view used to render a `SegmentElement`
 public class SegmentElementView: UIView {
-    private struct Layout {
-        static let TitleSegmentedControlSpacing: CGFloat = 12
+    public struct Layout {
+        let titleSegmentedControlSpacing: CGFloat
+
+        init(titleSegmentedControlSpacing: CGFloat = 12) {
+            self.titleSegmentedControlSpacing = titleSegmentedControlSpacing
+        }
     }
     
     /// The label that displays the title above the segmented control
@@ -21,7 +25,7 @@ public class SegmentElementView: UIView {
     /// The segmented control that displays the segments
     public let segmentedControl: UISegmentedControl
     
-    init(title: String, items: [SegmentContent]) {
+    init(title: String, items: [SegmentContent], layout: Layout = Layout()) {
         titleLabel = UILabel(frame: CGRectZero)
         titleLabel.font = UIFont.preferredFontForTextStyle(UIFontTextStyleSubheadline)
         titleLabel.text = title
@@ -33,7 +37,7 @@ public class SegmentElementView: UIView {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, segmentedControl])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .Vertical
-        stackView.spacing = Layout.TitleSegmentedControlSpacing
+        stackView.spacing = layout.titleSegmentedControlSpacing
         
         addSubview(stackView)
         stackView.activateSuperviewHuggingConstraints()


### PR DESCRIPTION
Currently the spacing between the title and the segmented control is hard coded to 12pt. This PR changes it so that the default is 12pt, but customizable.