### PR TITLE
Added accessoryIcon to SegueElement

### DIFF
--- a/Formalist/Convenience.swift
+++ b/Formalist/Convenience.swift
@@ -81,19 +81,24 @@ public func staticText(_ value: FormValue<String>, viewConfigurator: StaticTextE
  
  - parameter icon:             An optional icon to display
  - parameter title:            The title to display
+ - parameter accessoryIcon:        An optional icon to display in the accessory view
  - parameter viewConfigurator: An optional block used to configure the appearance
  of the view
  - parameter action:           The action to invoke when the view is tapped
  
  - returns: A segue element
  */
-public func segue(icon: UIImage?,
-                       title: String,
-                       viewConfigurator: SegueElement.ViewConfigurator? = nil,
-                       action: @escaping (Void) -> Void) -> SegueElement {
+public func segue(
+    icon: UIImage?,
+    title: String,
+    accessoryIcon: UIImage? = nil,
+    viewConfigurator: SegueElement.ViewConfigurator? = nil,
+    action: @escaping (Void) -> Void
+) -> SegueElement {
     return SegueElement(
         icon: icon,
         title: title,
+        accessoryIcon: accessoryIcon,
         viewConfigurator: viewConfigurator,
         action: action
     )

--- a/Formalist/SegueElement.swift
+++ b/Formalist/SegueElement.swift
@@ -15,6 +15,7 @@ public final class SegueElement: FormElement {
     
     fileprivate let icon: UIImage?
     fileprivate let title: String
+    fileprivate let accessoryIcon: UIImage?
     fileprivate let viewConfigurator: ViewConfigurator?
     fileprivate let action: (Void) -> Void
     
@@ -23,21 +24,23 @@ public final class SegueElement: FormElement {
      
      - parameter icon:             An optional icon to display
      - parameter title:            The title to display
+     - parameter accessoryIcon:        An optional icon to display in the accessory view
      - parameter viewConfigurator: An optional block used to configure the appearance
      of the view
      - parameter action:           The action to invoke when the view is tapped
      
      - returns: An initialized instance of the receiver
      */
-    public init(icon: UIImage?, title: String, viewConfigurator: ViewConfigurator? = nil, action: @escaping (Void) -> Void) {
+    public init(icon: UIImage?, title: String, accessoryIcon: UIImage?, viewConfigurator: ViewConfigurator? = nil, action: @escaping (Void) -> Void) {
         self.icon = icon
         self.title = title
+        self.accessoryIcon = accessoryIcon
         self.viewConfigurator = viewConfigurator
         self.action = action
     }
     
     public func render() -> UIView {
-        let view = SegueElementView(icon: icon, title: title)
+        let view = SegueElementView(icon: icon, title: title, accessoryIcon: accessoryIcon)
         viewConfigurator?(view)
         let tapGestureRecognizer = UITapGestureRecognizer(
             target: self,

--- a/Formalist/SegueElementView.swift
+++ b/Formalist/SegueElementView.swift
@@ -20,8 +20,11 @@ open class SegueElementView: UIView {
     
     /// The image view used to display the icon
     open let imageView: UIImageView
+
+    /// The button used to display the right icon
+    open let accessoryButton: UIButton
     
-    init(icon: UIImage?, title: String) {
+    init(icon: UIImage?, title: String, accessoryIcon: UIImage?) {
         label = UILabel(frame: CGRect.zero)
         label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
         label.text = title
@@ -29,10 +32,15 @@ open class SegueElementView: UIView {
         imageView = UIImageView(image: icon)
         imageView.isHidden = (icon == nil)
         imageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
-        
+
+        accessoryButton = UIButton(type: .custom)
+        accessoryButton.setImage(accessoryIcon, for: .normal)
+        accessoryButton.isHidden = (accessoryIcon == nil)
+        accessoryButton.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
+
         super.init(frame: CGRect.zero)
         
-        let stackView = UIStackView(arrangedSubviews: [imageView, label])
+        let stackView = UIStackView(arrangedSubviews: [imageView, label, accessoryButton])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.alignment = .center


### PR DESCRIPTION
Allows user to set accessoryIcon (right icon) for  `SegueElement`

<img width="315" alt="screen shot 2017-03-24 at 12 41 37 pm" src="https://cloud.githubusercontent.com/assets/1641795/24310969/3c44f952-108f-11e7-8ddc-7e1181287b3b.png">