### PR TITLE
Number Formatting for Text EditableTextElement

### DIFF
--- a/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UIViewController {
     fileprivate let floatLabelValue = FormValue("")
     fileprivate let multiLineFloatLabelValue = FormValue("")
     fileprivate let emailValue = FormValue("")
+    fileprivate let phoneValue = FormValue("")
     fileprivate let stringValue3 = FormValue("")
     fileprivate let pickerFieldValue = FormValue("")
     
@@ -32,7 +33,11 @@ class ViewController: UIViewController {
     
     fileprivate lazy var formViewController: FormViewController = {
         let edgeInsets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
-        
+
+        let numberFormatter = FormNumberFormatter(
+            type: .custom(pattern: "***-***-****", replaceCharacter: "*")
+        )
+
         var groupedConfiguration = GroupElement.Configuration()
         groupedConfiguration.style = .grouped(backgroundColor: .white)
         groupedConfiguration.layout.edgeInsets = edgeInsets
@@ -75,6 +80,19 @@ class ViewController: UIViewController {
                     $0.autocorrectionType = .no
                     $0.spellCheckingType = .no
                     $0.placeholder = "Text Field Element (Email)"
+                },
+                textField(
+                    value: self.phoneValue,
+                    configuration: TextEditorConfiguration(
+                        continuouslyUpdatesValue: true,
+                        formatter: numberFormatter
+                    ),
+                    validationRules: [.email])
+                {
+                    $0.autocapitalizationType = .none
+                    $0.autocorrectionType = .no
+                    $0.spellCheckingType = .no
+                    $0.placeholder = "Text formatter XXX-XXX-XXXX"
                 },
                 segue(icon: UIImage(named: "circle")!, title: "Segue Element", viewConfigurator: {
                     $0.accessibilityIdentifier = "segueView"

--- a/Formalist.xcodeproj/project.pbxproj
+++ b/Formalist.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		7285A7E71D17CF4F00718D23 /* Formalist.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7285A7061D17CB7000718D23 /* Formalist.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		72C817F31D1F910F00BBD0C3 /* FloatLabelTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C817F21D1F910F00BBD0C3 /* FloatLabelTextField.swift */; };
 		77A3050B1D7B6C7300F17EEF /* PickerField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A3050A1D7B6C7300F17EEF /* PickerField.swift */; };
+		77CAA13C1F2188E400EA44AD /* FormNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CAA13B1F2188E400EA44AD /* FormNumberFormatter.swift */; };
+		77CAA14E1F227BBE00EA44AD /* FormNumberFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CAA14D1F227BBE00EA44AD /* FormNumberFormatterTests.swift */; };
+		77CAA1501F23092400EA44AD /* Formattable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CAA14F1F23092400EA44AD /* Formattable.swift */; };
 		A15176551E16760100E5CCBC /* InfoFieldElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15176541E16760100E5CCBC /* InfoFieldElement.swift */; };
 		A151765D1E16763200E5CCBC /* DividerElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A151765C1E16763200E5CCBC /* DividerElement.swift */; };
 		A151765F1E1676E100E5CCBC /* AccessoryViewToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A151765E1E1676E100E5CCBC /* AccessoryViewToolbar.swift */; };
@@ -233,6 +236,9 @@
 		7285A7D21D17CDAC00718D23 /* StackViewController.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = StackViewController.xcodeproj; path = External/StackViewController/StackViewController.xcodeproj; sourceTree = "<group>"; };
 		72C817F21D1F910F00BBD0C3 /* FloatLabelTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatLabelTextField.swift; sourceTree = "<group>"; };
 		77A3050A1D7B6C7300F17EEF /* PickerField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PickerField.swift; sourceTree = "<group>"; };
+		77CAA13B1F2188E400EA44AD /* FormNumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormNumberFormatter.swift; sourceTree = "<group>"; };
+		77CAA14D1F227BBE00EA44AD /* FormNumberFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormNumberFormatterTests.swift; sourceTree = "<group>"; };
+		77CAA14F1F23092400EA44AD /* Formattable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formattable.swift; sourceTree = "<group>"; };
 		A15176541E16760100E5CCBC /* InfoFieldElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoFieldElement.swift; sourceTree = "<group>"; };
 		A151765C1E16763200E5CCBC /* DividerElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividerElement.swift; sourceTree = "<group>"; };
 		A151765E1E1676E100E5CCBC /* AccessoryViewToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessoryViewToolbar.swift; sourceTree = "<group>"; };
@@ -331,6 +337,7 @@
 				7285A7661D17CC1D00718D23 /* ValidationErrorViewTests.swift */,
 				7285A7671D17CC1D00718D23 /* ValidationRuleTests.swift */,
 				7285A7681D17CC1D00718D23 /* ViewElementTests.swift */,
+				77CAA14D1F227BBE00EA44AD /* FormNumberFormatterTests.swift */,
 			);
 			path = FormalistTests;
 			sourceTree = "<group>";
@@ -444,6 +451,8 @@
 				7285A72B1D17CBCA00718D23 /* PlaceholderTextView.swift */,
 				72C817F21D1F910F00BBD0C3 /* FloatLabelTextField.swift */,
 				77A3050A1D7B6C7300F17EEF /* PickerField.swift */,
+				77CAA13B1F2188E400EA44AD /* FormNumberFormatter.swift */,
+				77CAA14F1F23092400EA44AD /* Formattable.swift */,
 			);
 			name = "Editable Text";
 			sourceTree = "<group>";
@@ -735,6 +744,7 @@
 				7285A74B1D17CBCA00718D23 /* SegmentElementView.swift in Sources */,
 				7285A7541D17CBCA00718D23 /* UIView+FormResponder.swift in Sources */,
 				7285A74D1D17CBCA00718D23 /* SegueElementView.swift in Sources */,
+				77CAA13C1F2188E400EA44AD /* FormNumberFormatter.swift in Sources */,
 				77A3050B1D7B6C7300F17EEF /* PickerField.swift in Sources */,
 				72239FEB1D25B9E800A157D9 /* UIView+ChangeObservation.swift in Sources */,
 				7285A7421D17CBCA00718D23 /* FloatLabel.swift in Sources */,
@@ -747,6 +757,7 @@
 				7285A74A1D17CBCA00718D23 /* SegmentElement.swift in Sources */,
 				A151765F1E1676E100E5CCBC /* AccessoryViewToolbar.swift in Sources */,
 				7285A7451D17CBCA00718D23 /* FormValue.swift in Sources */,
+				77CAA1501F23092400EA44AD /* Formattable.swift in Sources */,
 				7285A7501D17CBCA00718D23 /* TextEditorAdapter.swift in Sources */,
 				7285A73E1D17CBCA00718D23 /* BooleanElementView.swift in Sources */,
 				7285A7471D17CBCA00718D23 /* GroupElement.swift in Sources */,
@@ -764,6 +775,7 @@
 			files = (
 				7285A76B1D17CC1D00718D23 /* FloatLabelTests.swift in Sources */,
 				7285A7771D17CC1D00718D23 /* ViewElementTests.swift in Sources */,
+				77CAA14E1F227BBE00EA44AD /* FormNumberFormatterTests.swift in Sources */,
 				7285A7761D17CC1D00718D23 /* ValidationRuleTests.swift in Sources */,
 				7285A76E1D17CC1D00718D23 /* PlaceholderTextViewTests.swift in Sources */,
 				7285A7691D17CC1D00718D23 /* BooleanElementTests.swift in Sources */,

--- a/Formalist/EditableTextElement.swift
+++ b/Formalist/EditableTextElement.swift
@@ -47,12 +47,10 @@ public final class EditableTextElement<AdapterType: TextEditorAdapter>: FormElem
             guard let `self` = self else { return }
 
             let text: String = {
-                let oldValue = self.value.value
                 let newValue = adapter.getTextForView(view)
                 if let formatter = self.configuration.formatter {
                     return formatter.from(
-                        input: newValue,
-                        previousInput: oldValue
+                        input: newValue
                     )
                 } else {
                     return newValue

--- a/Formalist/FormNumberFormatter.swift
+++ b/Formalist/FormNumberFormatter.swift
@@ -23,18 +23,16 @@ public struct FormNumberFormatter: Formattable {
         self.type = type
     }
 
-    public func from(input: String, previousInput: String = "") -> String {
+    public func from(input: String) -> String {
         let newValue = input.digits
         var result = ""
         let pattern = type.pattern
         let replaceCharacter = type.replaceCharacter
         var newValueIndex = newValue.startIndex
         var patternIndex = pattern.startIndex
-        let isRemoving = newValue.characters.count < previousInput.characters.count
 
         while patternIndex < pattern.endIndex && newValueIndex < newValue.endIndex  {
             let value = pattern[patternIndex]
-
             if value == replaceCharacter {
                 result.append(newValue[newValueIndex])
                 newValueIndex = newValue.index(newValueIndex, offsetBy: 1)
@@ -42,21 +40,6 @@ public struct FormNumberFormatter: Formattable {
                 result.append(value)
             }
             patternIndex = pattern.index(patternIndex, offsetBy: 1)
-
-            if newValueIndex == newValue.endIndex && patternIndex < pattern.endIndex && pattern[patternIndex] != replaceCharacter {
-                if isRemoving {
-                    if previousInput.characters.last != pattern[patternIndex] {
-                        result.append(pattern[patternIndex])
-                    } else {
-                        result = String(result.characters.dropLast())
-                    }
-                } else {
-                    while pattern[patternIndex] != replaceCharacter {
-                        result.append(pattern[patternIndex])
-                        patternIndex = pattern.index(patternIndex, offsetBy: 1)
-                    }
-                }
-            }
         }
         return result
     }

--- a/Formalist/Formattable.swift
+++ b/Formalist/Formattable.swift
@@ -1,0 +1,13 @@
+//
+//  Formattable.swift
+//  Formalist
+//
+//  Created by Viktor Radchenko on 7/21/17.
+//  Copyright © 2017 Seed Platform, Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol Formattable {
+    func from(input: String, previousInput: String) -> String
+}

--- a/Formalist/Formattable.swift
+++ b/Formalist/Formattable.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public protocol Formattable {
-    func from(input: String, previousInput: String) -> String
+    func from(input: String) -> String
 }

--- a/Formalist/TextEditorConfiguration.swift
+++ b/Formalist/TextEditorConfiguration.swift
@@ -32,6 +32,7 @@ public struct TextEditorConfiguration {
     public let shouldResignFirstResponderWhenFinished: Bool
     public let showAccessoryViewToolbar: Bool
     public let textEditorAction: ((TextEditorAction) -> Void)?
+    public let formatter: Formattable?
 
     /**
      Designated initializer
@@ -53,6 +54,7 @@ public struct TextEditorConfiguration {
         maximumLength: Int? = nil,
         shouldResignFirstResponderWhenFinished: Bool = true,
         showAccessoryViewToolbar: Bool = false,
+        formatter: Formattable? = nil,
         textEditorAction: ((TextEditorAction) -> Void)? = nil
     ) {
         self.returnKeyAction = returnKeyAction
@@ -60,6 +62,7 @@ public struct TextEditorConfiguration {
         self.maximumLength = maximumLength
         self.shouldResignFirstResponderWhenFinished = shouldResignFirstResponderWhenFinished
         self.showAccessoryViewToolbar = showAccessoryViewToolbar
+        self.formatter = formatter
         self.textEditorAction = textEditorAction
     }
 }

--- a/Formalist/ValidationRule.swift
+++ b/Formalist/ValidationRule.swift
@@ -106,7 +106,7 @@ public struct ValidationRule<ValueType> {
 
      - returns: The validation rule
      */
-    public static func characterSet(_ characterSet: NSCharacterSet) -> ValidationRule<String> {
+    public static func characterSet(_ characterSet: CharacterSet) -> ValidationRule<String> {
         return ValidationRule<String> ({ str, completion in
             if let range = str.rangeOfCharacter(from: characterSet.inverted) {
                 let errorFormat = NSLocalizedString("\"%@\" is not an allowed character", comment: "Invalid character error message")

--- a/FormalistTests/FormNumberFormatterTests.swift
+++ b/FormalistTests/FormNumberFormatterTests.swift
@@ -1,0 +1,216 @@
+//
+//  FormNumberFormatterTests.swift
+//  Formalist
+//
+//  Created by Viktor Radchenko on 7/21/17.
+//  Copyright © 2017 Seed Platform, Inc. All rights reserved.
+//
+
+import XCTest
+@testable import Formalist
+
+class FormNumberFormatterTests: XCTestCase {
+
+    func testFormatting1() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = ""
+
+        XCTAssertEqual("", formatter.from(input: value))
+    }
+
+    func testFormatting2() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "11"
+
+        XCTAssertEqual("11", formatter.from(input: value))
+    }
+
+    func testFormatting3() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "1234567890"
+
+        XCTAssertEqual("123-456-7890", formatter.from(input: value))
+    }
+
+    func testFormatting4() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123"
+
+        XCTAssertEqual("123-", formatter.from(input: value))
+    }
+
+    func testFormatting5() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123456"
+
+        XCTAssertEqual("123-456-", formatter.from(input: value))
+    }
+
+    func testFormatting6() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "12345678901111"
+
+        XCTAssertEqual("123-456-7890", formatter.from(input: value))
+    }
+
+    func testFormatting7() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123456789"
+
+        XCTAssertEqual("123-456-789", formatter.from(input: value))
+    }
+
+    func testFormatting8() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123"
+
+        XCTAssertEqual("", formatter.from(input: value))
+    }
+
+    func testFormatting9() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "X",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123"
+
+        XCTAssertEqual("1", formatter.from(input: value))
+    }
+
+    func testFormatting10() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "SSS",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123"
+
+        XCTAssertEqual("SSS", formatter.from(input: value))
+    }
+
+    func testFormatting11() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX--XXX--XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123456"
+
+        XCTAssertEqual("123--456--", formatter.from(input: value))
+    }
+
+    func testFormatting12() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "!XXX-!-XXX-!-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "123456"
+
+        XCTAssertEqual("!123-!-456-!-", formatter.from(input: value))
+    }
+
+    func testFormattingPhoneNumber1() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "XXX-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "1234567890"
+
+        XCTAssertEqual("123-456-7890", formatter.from(input: value))
+    }
+
+    func testFormattingPhoneNumber2() {
+        let formatter = FormNumberFormatter(
+            type: .custom(
+                pattern: "(XXX)-XXX-XXXX",
+                replaceCharacter: "X"
+            )
+        )
+        let value = "1234567890"
+
+        XCTAssertEqual("(123)-456-7890", formatter.from(input: value))
+    }
+
+    func testFormattingSocialSecurity() {
+        let formatter = FormNumberFormatter(type: .SSN)
+        let value = "123456789"
+
+        XCTAssertEqual("123-45-6789", formatter.from(input: value))
+    }
+
+    func testFormattingEIN() {
+        let formatter = FormNumberFormatter(type: .EIN)
+        let value = "123456789"
+
+        XCTAssertEqual("12-3456789", formatter.from(input: value))
+    }
+
+    func testFormattingCreditCard() {
+        let formatter = FormNumberFormatter(type: .creditCard)
+        let value = "1234123412341234"
+
+        XCTAssertEqual("1234 1234 1234 1234", formatter.from(input: value))
+    }
+}
+
+extension FormNumberFormatter {
+    static func make(
+        pattern: String = "XXX-XXX-XXXX",
+        replaceCharacter: Character = "X"
+    ) -> FormNumberFormatter {
+        return FormNumberFormatter(
+            type: .custom(
+                pattern: pattern,
+                replaceCharacter: replaceCharacter
+            )
+        )
+    }
+}

--- a/FormalistTests/FormNumberFormatterTests.swift
+++ b/FormalistTests/FormNumberFormatterTests.swift
@@ -54,9 +54,9 @@ class FormNumberFormatterTests: XCTestCase {
                 replaceCharacter: "X"
             )
         )
-        let value = "123"
+        let value = "1234"
 
-        XCTAssertEqual("123-", formatter.from(input: value))
+        XCTAssertEqual("123-4", formatter.from(input: value))
     }
 
     func testFormatting5() {
@@ -68,7 +68,7 @@ class FormNumberFormatterTests: XCTestCase {
         )
         let value = "123456"
 
-        XCTAssertEqual("123-456-", formatter.from(input: value))
+        XCTAssertEqual("123-456", formatter.from(input: value))
     }
 
     func testFormatting6() {
@@ -140,7 +140,7 @@ class FormNumberFormatterTests: XCTestCase {
         )
         let value = "123456"
 
-        XCTAssertEqual("123--456--", formatter.from(input: value))
+        XCTAssertEqual("123--456", formatter.from(input: value))
     }
 
     func testFormatting12() {
@@ -152,7 +152,7 @@ class FormNumberFormatterTests: XCTestCase {
         )
         let value = "123456"
 
-        XCTAssertEqual("!123-!-456-!-", formatter.from(input: value))
+        XCTAssertEqual("!123-!-456", formatter.from(input: value))
     }
 
     func testFormattingPhoneNumber1() {

--- a/FormalistTests/ValidationRuleTests.swift
+++ b/FormalistTests/ValidationRuleTests.swift
@@ -20,15 +20,17 @@ class ValidationRuleTests: XCTestCase {
     }
     
     func testValidateWithAllValidRules() {
+
         var evaluated1 = false, evaluated2 = false
-        let rule1 = ValidationRule<String> { _, completion in
+        let rule1 = ValidationRule<String> ({ _, completion in
             evaluated1 = true
             completion(.valid)
-        }
-        let rule2 = ValidationRule<String> { _, completion in
+        }, identifier: "rule1")
+
+        let rule2 = ValidationRule<String> ( { _, completion in
             evaluated2 = true
             completion(.valid)
-        }
+        }, identifier: "rule2")
         
         let expectation = self.expectation(description: "validate rules")
         ValidationRule.validateRules([rule1, rule2], forValue: "") { result in
@@ -43,14 +45,14 @@ class ValidationRuleTests: XCTestCase {
     func testValidateWithOneInvalidRule() {
         var evaluated1 = false, evaluated2 = false
         let invalidResult = ValidationResult.invalid(message: "Validation failed")
-        let rule1 = ValidationRule<String> { _, completion in
+        let rule1 = ValidationRule<String> ({ _, completion in
             evaluated1 = true
             completion(invalidResult)
-        }
-        let rule2 = ValidationRule<String> { _, completion in
+        }, identifier: "rule1")
+        let rule2 = ValidationRule<String> ({ _, completion in
             evaluated2 = true
             completion(.valid)
-        }
+        }, identifier: "rule1")
         
         let expectation = self.expectation(description: "validate rules")
         ValidationRule.validateRules([rule1, rule2], forValue: "") { result in
@@ -64,14 +66,14 @@ class ValidationRuleTests: XCTestCase {
     
     func testValidateWithOneCancelledRule() {
         var evaluated1 = false, evaluated2 = false
-        let rule1 = ValidationRule<String> { _, completion in
+        let rule1 = ValidationRule<String> ({ _, completion in
             evaluated1 = true
             completion(.cancelled)
-        }
-        let rule2 = ValidationRule<String> { _, completion in
+        }, identifier: "rule1")
+        let rule2 = ValidationRule<String> ({ _, completion in
             evaluated2 = true
             completion(.valid)
-        }
+        }, identifier: "rule2")
         
         let expectation = self.expectation(description: "validate rules")
         ValidationRule.validateRules([rule1, rule2], forValue: "") { result in


### PR DESCRIPTION
Implemented TextFormatter to allow setting pattern formatting for specific fields. 

`TextEditorConfiguration` has a property `TextFormatter` , if user set pattern: `XXX-XXX-XXXX` and replaceCharacter: `replaceCharacter` that field would be formatted that way while tapping. 

This ideal for formatting fields like phone number, social security, EIN, credit card number.

Created `FormNumberFormatter` formatter that conform to `Formattable`, realized with @louoso that it's little tricky to support alphabetic values, for now it's gonna support just digits for formatting. 
 
I'm just typing number, it automatically adds `-` in between. 
![text-formatting](https://user-images.githubusercontent.com/1641795/28485581-5172e73c-6e2f-11e7-8d41-78bc6a33f9ed.gif)