### PR TITLE
Support multiline title in SegueElementView 

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -113,7 +113,11 @@ class ViewController: UIViewController {
                     activityIndicator.startAnimating()
                     return activityIndicator
                 }
-            ])
+            ]),
+            group(configuration: groupedConfiguration, elements: [
+                segue(icon: UIImage(named: "circle")!, title: "Short title", accessoryIcon: UIImage(named: "circle")!, viewConfigurator: nil) {},
+                segue(icon: UIImage(named: "circle")!, title: "This segue supports multiline title. As you can see here. ", accessoryIcon: UIImage(named: "circle")!, viewConfigurator: nil) {}
+            ]),
         ])
     }()
 

--- a/Formalist/SegueElementView.swift
+++ b/Formalist/SegueElementView.swift
@@ -14,24 +14,30 @@ open class SegueElementView: UIView {
     fileprivate struct Layout {
         static let IconLabelSpacing: CGFloat = 10.0
     }
-    
+
     /// The label used to display the title
     open let label: UILabel
-    
+
     /// The image view used to display the icon
     open let imageView: UIImageView
 
     /// The button used to display the right icon
     open let accessoryButton: UIButton
-    
+
     init(icon: UIImage?, title: String, accessoryIcon: UIImage?) {
-        label = UILabel(frame: CGRect.zero)
-        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
-        label.text = title
-        
         imageView = UIImageView(image: icon)
         imageView.isHidden = (icon == nil)
         imageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
+
+        label = UILabel(frame: CGRect.zero)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
+        label.text = title
+        label.numberOfLines = 0
+        label.setContentCompressionResistancePriority(UILayoutPriorityDefaultLow, for: .horizontal)
+
+        let labelView = UIView()
+        labelView.addSubview(label)
 
         accessoryButton = UIButton(type: .custom)
         accessoryButton.setImage(accessoryIcon, for: .normal)
@@ -39,19 +45,20 @@ open class SegueElementView: UIView {
         accessoryButton.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
 
         super.init(frame: CGRect.zero)
-        
-        let stackView = UIStackView(arrangedSubviews: [imageView, label, accessoryButton])
+
+        let stackView = UIStackView(arrangedSubviews: [imageView, labelView, accessoryButton])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = Layout.IconLabelSpacing
-        
+
+        let _ = label.activateSuperviewHuggingConstraints()
+
         addSubview(stackView)
         let _ = stackView.activateSuperviewHuggingConstraints()
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
-


### PR DESCRIPTION
Initially could not make `UILabel` to work properly when you set `numberOfLines = 0`, setting content resistance or hugging won’t do anything. 
Stumble upon this solution: https://stackoverflow.com/a/38294467 to wrap `UILabel` into `UIView` and put it in the `stackView`.

I was surprised :) 

Result in the last two rows:
![simulator screen shot - iphone se - 2017-08-22 at 13 31 07](https://user-images.githubusercontent.com/1641795/29586132-891187de-873e-11e7-910d-ebaf08a295b6.png)