### PR TITLE
Make the different FormElements more discoverable

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -44,45 +44,45 @@ class ViewController: UIViewController {
         groupedConfiguration.layout.edgeInsets = edgeInsets
         
         return FormViewController(elements: [
-            inset(edgeInsets, elements: [
-                staticText("Welcome to the Formalist Catalog app. This text is an example of a StaticTextElement. Other kinds of elements are showcased below.") {
+            .inset(edgeInsets, elements: [
+                .staticText("Welcome to the Formalist Catalog app. This text is an example of a StaticTextElement. Other kinds of elements are showcased below.") {
                     $0.textAlignment = .center
                     $0.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.footnote)
                 }
             ]),
-            group(configuration: groupedConfiguration, elements: [
-                toggle(title: "Boolean Element", value: self.booleanValue, icon: UIImage(named: "circle")!),
-                textView(value: self.textViewValue) {
+            .group(configuration: groupedConfiguration, elements: [
+                .toggle(title: "Boolean Element", value: self.booleanValue, icon: UIImage(named: "circle")!),
+                .textView(value: self.textViewValue) {
                     $0.placeholder = "Text View Element"
                     $0.accessibilityIdentifier = "textView"
                 },
-                singleLineFloatLabel(name: "Float Label Element", value: self.floatLabelValue) {
+                .singleLineFloatLabel(name: "Float Label Element", value: self.floatLabelValue) {
                     $0.textEntryView.accessibilityIdentifier = "floatLabel"
                 },
-                multiLineFloatLabel(name: "Float MultiLine Element", value: self.multiLineFloatLabelValue) {
+                .multiLineFloatLabel(name: "Float MultiLine Element", value: self.multiLineFloatLabelValue) {
                     $0.textEntryView.accessibilityIdentifier = "multiLineFloatLabel"
                 },
-                pickerField(name: "Picker Field Element", value: self.pickerFieldValue, items: [
+                .pickerField(name: "Picker Field Element", value: self.pickerFieldValue, items: [
                     PickerValue(title: "Value #1", value: "value1"),
                     PickerValue(title: "Value #2", value: "value2"),
                     PickerValue(title: "Value #3", value: "value3")
                 ]) {
                     $0.textEntryView.accessibilityIdentifier = "pickerField"
                 },
-                segments(title: "Segment Element", segments: [
+                .segments(title: "Segment Element", segments: [
                     Segment(content: .title("Segment 1"), value: "Segment 1"),
                     Segment(content: .title("Segment 2"), value: "Segment 2")
                 ], selectedValue: self.segmentValue),
             ]),
-            spacer(height: 20.0),
-            group(configuration: groupedConfiguration, elements: [
-                textField(value: self.emailValue, configuration: TextEditorConfiguration(continuouslyUpdatesValue: true), validationRules: [.email]) {
+            .spacer(height: 20.0),
+            .group(configuration: groupedConfiguration, elements: [
+                .textField(value: self.emailValue, configuration: TextEditorConfiguration(continuouslyUpdatesValue: true), validationRules: [.email]) {
                     $0.autocapitalizationType = .none
                     $0.autocorrectionType = .no
                     $0.spellCheckingType = .no
                     $0.placeholder = "Text Field Element (Email)"
                 },
-                textField(
+                .textField(
                     value: self.phoneValue,
                     configuration: TextEditorConfiguration(
                         continuouslyUpdatesValue: true,
@@ -95,28 +95,28 @@ class ViewController: UIViewController {
                     $0.spellCheckingType = .no
                     $0.placeholder = "Text formatter XXX-XXX-XXXX"
                 },
-                segue(icon: UIImage(named: "circle")!, title: "Segue Element", viewConfigurator: {
+                .segue(icon: UIImage(named: "circle")!, title: "Segue Element", viewConfigurator: {
                     $0.accessibilityIdentifier = "segueView"
                 }) { [unowned self] in
                     self.displayAlertWithTitle("Segue Element", message: "Tapped the element.")
                 },
             ]),
-            inset(edgeInsets, elements: [
+            .inset(edgeInsets, elements: [
                 StaticTextElement(text: "Views can be easily wrapped to create custom form elements without subclassing, which is how this activity indicator is implemented.") {
                     $0.textAlignment = .center
                     $0.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.footnote)
                 }
             ]),
-            group(configuration: groupedConfiguration, elements: [
-                customView(value: FormValue("")) { _ in
+            .group(configuration: groupedConfiguration, elements: [
+                .customView(value: FormValue("")) { _ in
                     let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
                     activityIndicator.startAnimating()
                     return activityIndicator
                 }
             ]),
-            group(configuration: groupedConfiguration, elements: [
-                segue(icon: UIImage(named: "circle")!, title: "Short title", accessoryIcon: UIImage(named: "circle")!, viewConfigurator: nil) {},
-                segue(icon: UIImage(named: "circle")!, title: "This segue supports multiline title. As you can see here. ", accessoryIcon: UIImage(named: "circle")!, viewConfigurator: nil) {}
+            .group(configuration: groupedConfiguration, elements: [
+                .segue(icon: UIImage(named: "circle")!, title: "Short title", accessoryIcon: UIImage(named: "circle")!, viewConfigurator: nil) {},
+                .segue(icon: UIImage(named: "circle")!, title: "This segue supports multiline title. As you can see here. ", accessoryIcon: UIImage(named: "circle")!, viewConfigurator: nil) {}
             ]),
         ])
     }()

--- a/Formalist/BooleanElement.swift
+++ b/Formalist/BooleanElement.swift
@@ -35,7 +35,7 @@ public final class BooleanElement: FormElement {
         self.viewConfigurator = viewConfigurator
     }
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let booleanView = BooleanElementView(title: title, icon: icon)
         booleanView.toggle.addTarget(
             self,

--- a/Formalist/Convenience.swift
+++ b/Formalist/Convenience.swift
@@ -18,6 +18,7 @@
  
  - returns: A boolean element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func toggle(title: String, value: FormValue<Bool>, icon: UIImage? = nil, viewConfigurator: BooleanElement.ViewConfigurator? = nil) -> BooleanElement {
     return BooleanElement(title: title, value: value, icon: icon, viewConfigurator: viewConfigurator)
 }
@@ -35,6 +36,7 @@ public func toggle(title: String, value: FormValue<Bool>, icon: UIImage? = nil, 
  
  - returns: A segment element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func segments<ValueType>(title: String,
                                                  segments: [Segment<ValueType>],
                                                  selectedValue: FormValue<ValueType>,
@@ -58,6 +60,7 @@ public func segments<ValueType>(title: String,
  
  - returns: A static text form element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func staticText(_ text: String, viewConfigurator: StaticTextElement.ViewConfigurator? = nil) -> StaticTextElement {
     return StaticTextElement(text: text, viewConfigurator: viewConfigurator)
 }
@@ -72,6 +75,7 @@ public func staticText(_ text: String, viewConfigurator: StaticTextElement.ViewC
  
  - returns: A static text form element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func staticText(_ value: FormValue<String>, viewConfigurator: StaticTextElement.ViewConfigurator? = nil) -> StaticTextElement {
     return StaticTextElement(value: value, viewConfigurator: viewConfigurator)
 }
@@ -89,6 +93,7 @@ public func staticText(_ value: FormValue<String>, viewConfigurator: StaticTextE
  
  - returns: A segue element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func segue(
     icon: UIImage?,
     title: String,
@@ -115,6 +120,7 @@ public func segue(
  
  - returns: A spacer element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func spacer(height: CGFloat, viewConfigurator: SpacerElement.ViewConfigurator? = nil) -> SpacerElement {
     return SpacerElement(height: height, viewConfigurator: viewConfigurator)
 }
@@ -129,6 +135,7 @@ public func spacer(height: CGFloat, viewConfigurator: SpacerElement.ViewConfigur
  
  - returns: A view element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func customView<ValueType>(
   value: FormValue<ValueType>,
   viewConfigurator: @escaping ViewElement<ValueType>.ViewConfigurator
@@ -146,6 +153,7 @@ public func customView<ValueType>(
  
  - returns: A group element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func group(configuration: GroupElement.Configuration = GroupElement.Configuration(), elements: [FormElement]) -> GroupElement {
     return GroupElement(configuration: configuration, elements: elements)
 }
@@ -159,6 +167,7 @@ public func group(configuration: GroupElement.Configuration = GroupElement.Confi
  
  - returns: A group element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func group(configurator: (inout GroupElement.Configuration) -> Void, elements: [FormElement]) -> GroupElement {
     return GroupElement(configurator: configurator, elements: elements)
 }
@@ -171,6 +180,7 @@ public func group(configurator: (inout GroupElement.Configuration) -> Void, elem
  
  - returns: A group element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func inset(_ insets: UIEdgeInsets, elements: [FormElement]) -> GroupElement {
     return GroupElement(configurator: {
         $0.layout.edgeInsets = insets
@@ -188,6 +198,7 @@ public func inset(_ insets: UIEdgeInsets, elements: [FormElement]) -> GroupEleme
  
  - returns: An editable text element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func textField(value: FormValue<String>,
                             configuration: TextEditorConfiguration = TextEditorConfiguration(),
                             validationRules: [ValidationRule<String>] = [],
@@ -212,6 +223,7 @@ public func textField(value: FormValue<String>,
  
  - returns: An editable text element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func textView(value: FormValue<String>,
                            configuration: TextEditorConfiguration = TextEditorConfiguration(returnKeyAction: .none),
                            validationRules: [ValidationRule<String>] = [],
@@ -237,6 +249,7 @@ public func textView(value: FormValue<String>,
  
  - returns: An editable text elemen
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func floatLabel
     <InnerAdapterType>
     (name: String,
@@ -266,6 +279,7 @@ public func floatLabel
  
  - returns: An editable text elemen
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func singleLineFloatLabel(name: String,
                                       value: FormValue<String>,
                                       configuration: TextEditorConfiguration = TextEditorConfiguration(),
@@ -294,6 +308,7 @@ public func singleLineFloatLabel(name: String,
  
  - returns: An editable text element
  */
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func multiLineFloatLabel(name: String,
                                      value: FormValue<String>,
                                      configuration: TextEditorConfiguration = TextEditorConfiguration(returnKeyAction: .none),
@@ -322,7 +337,7 @@ public func multiLineFloatLabel(name: String,
  
  - returns: An editable text element
  */
-
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func pickerField<ValueType>(name: String, value: FormValue<ValueType>, items: [PickerValue<ValueType>],
                                 configuration: TextEditorConfiguration = TextEditorConfiguration(),
                                 validationRules: [ValidationRule<String>] = [],
@@ -351,10 +366,12 @@ public func pickerField<ValueType>(name: String, value: FormValue<ValueType>, it
         }
 }
 
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func infoField(title: NSMutableAttributedString, subTitle: NSMutableAttributedString, viewConfigurator: ((UILabel, UILabel) -> Void)? = nil) -> InfoFieldElement {
     return InfoFieldElement(title: title, subTitle: subTitle, viewConfigurator: viewConfigurator)
 }
 
+@available(*, deprecated, message: "The free functions have been deprecated. Use the static functions on FormElement instead.")
 public func divider(color: UIColor = .black, height: CGFloat = 1, viewConfigurator: ((UIView) -> Void)? = nil) -> DividerElement {
     return DividerElement(color: color, height: height, viewConfigurator:  viewConfigurator)
 }

--- a/Formalist/Convenience.swift
+++ b/Formalist/Convenience.swift
@@ -6,6 +6,362 @@
 //  Copyright © 2016 Seed Platform, Inc. All rights reserved.
 //
 
+extension FormElement {
+    /**
+     Creates a form element that displays a control to toggle a boolean value
+     Convenience function for initializing a `BooleanElement`
+
+     - parameter title:            The title to display to the toggle
+     - parameter value:            The form value to bind to the toggle
+     - parameter icon:             An optional image to add beside the toggle
+     - parameter viewConfigurator: An optional closure that can configure the
+     element view, including the title `UILabel` and toggle `UISwitch`
+
+     - returns: A boolean element
+     */
+    public static func toggle(title: String, value: FormValue<Bool>, icon: UIImage? = nil, viewConfigurator: BooleanElement.ViewConfigurator? = nil) -> BooleanElement {
+        return BooleanElement(title: title, value: value, icon: icon, viewConfigurator: viewConfigurator)
+    }
+
+    /**
+     Creates a form element that displays a segmented control
+     Convenience function for initializing a `SegmentElement`
+
+     - parameter title:            The title to display above the segmented control
+     - parameter segments:         The segments to display in the segmented control
+     - parameter selectedValue:    The value to bind to the value of the selected
+     segment
+     - parameter viewConfigurator: An optional closure for configuring the appearance
+     of the view, including the title label and segmented control
+
+     - returns: A segment element
+     */
+    public static func segments<ValueType>(title: String,
+                                    segments: [Segment<ValueType>],
+                                    selectedValue: FormValue<ValueType>,
+                                    viewConfigurator: SegmentElement<ValueType>.ViewConfigurator? = nil)
+        -> SegmentElement<ValueType> {
+            return SegmentElement(
+                title: title,
+                segments: segments,
+                selectedValue: selectedValue,
+                viewConfigurator: viewConfigurator
+            )
+    }
+
+    /**
+     Creates a form element that displays static text.
+     Convenience function for initializing a `StaticTextElement`
+
+     - parameter text:             The text to display
+     - parameter viewConfigurator: An optional block used to configure the appearance
+     of the view
+
+     - returns: A static text form element
+     */
+    public static func staticText(_ text: String, viewConfigurator: StaticTextElement.ViewConfigurator? = nil) -> StaticTextElement {
+        return StaticTextElement(text: text, viewConfigurator: viewConfigurator)
+    }
+
+    /**
+     Creates a form element that displays static text.
+     Convenience function for initializing a `StaticTextElement`
+
+     - parameter value:            The text value to bind to the label
+     - parameter viewConfigurator: An optional block used to configure the appearance
+     of the view
+
+     - returns: A static text form element
+     */
+    public static func staticText(_ value: FormValue<String>, viewConfigurator: StaticTextElement.ViewConfigurator? = nil) -> StaticTextElement {
+        return StaticTextElement(value: value, viewConfigurator: viewConfigurator)
+    }
+
+    /**
+     Creates a form element that displays a cell that invokes an action when tapped
+     Convenience function for initializing a `SegueElement`
+
+     - parameter icon:             An optional icon to display
+     - parameter title:            The title to display
+     - parameter accessoryIcon:        An optional icon to display in the accessory view
+     - parameter viewConfigurator: An optional block used to configure the appearance
+     of the view
+     - parameter action:           The action to invoke when the view is tapped
+
+     - returns: A segue element
+     */
+    public static func segue(
+        icon: UIImage?,
+        title: String,
+        accessoryIcon: UIImage? = nil,
+        viewConfigurator: SegueElement.ViewConfigurator? = nil,
+        action: @escaping () -> Void
+        ) -> SegueElement {
+        return SegueElement(
+            icon: icon,
+            title: title,
+            accessoryIcon: accessoryIcon,
+            viewConfigurator: viewConfigurator,
+            action: action
+        )
+    }
+
+    /**
+     Creates a form element that displays a fixed height spacer
+     Convenience function for initializing a `SpacerElement`
+
+     - parameter height:           The height of the spacer
+     - parameter viewConfigurator: An optional block used to configure the
+     appearance of the spacer view
+
+     - returns: A spacer element
+     */
+    public static func spacer(height: CGFloat, viewConfigurator: SpacerElement.ViewConfigurator? = nil) -> SpacerElement {
+        return SpacerElement(height: height, viewConfigurator: viewConfigurator)
+    }
+
+    /**
+     Creates a form element that wraps an existing view
+     Convenience function for initializing a `ViewElement`
+
+     - parameter value:            The value to bind to the element
+     - parameter viewConfigurator: A block that creates and configures
+     a view associated with the element
+
+     - returns: A view element
+     */
+    public static func customView<ValueType>(
+        value: FormValue<ValueType>,
+        viewConfigurator: @escaping ViewElement<ValueType>.ViewConfigurator
+        ) -> ViewElement<ValueType> {
+        return ViewElement(value: value, viewConfigurator: viewConfigurator)
+    }
+
+    /**
+     Creates a form element that groups child elements
+     Convenience function for initializing a `GroupElement`
+
+     - parameter configuration: The configuration parameters to use. See the
+     documentation for the `Configuration` struct.
+     - parameter elements:      The elements to group
+
+     - returns: A group element
+     */
+    public static func group(configuration: GroupElement.Configuration = GroupElement.Configuration(), elements: [FormElement]) -> GroupElement {
+        return GroupElement(configuration: configuration, elements: elements)
+    }
+
+    /**
+     Creates a form element that groups child elements
+     Convenience function for initializing a `GroupElement`
+
+     - parameter configurator: Block used to set up configuration properties
+     - parameter elements:     The elements to group
+
+     - returns: A group element
+     */
+    public static func group(configurator: (inout GroupElement.Configuration) -> Void, elements: [FormElement]) -> GroupElement {
+        return GroupElement(configurator: configurator, elements: elements)
+    }
+
+    /**
+     Creates a group element that insets the specified child elements
+
+     - parameter insets:   The insets to apply to the child elements
+     - parameter elements: The child elements to inset
+
+     - returns: A group element
+     */
+    public static func inset(_ insets: UIEdgeInsets, elements: [FormElement]) -> GroupElement {
+        return GroupElement(configurator: {
+            $0.layout.edgeInsets = insets
+        }, elements: elements)
+    }
+
+    /**
+     Creates an editable text element that renders a `UITextField`
+
+     - parameter value:            The string value to bind to the text field
+     - parameter configuration:    Configuration options for the text field
+     - parameter validationRules:  Rules used to validate the string value
+     - parameter viewConfigurator: An optional block used to perform additional
+     customization of the text field.
+
+     - returns: An editable text element
+     */
+    public static func textField(value: FormValue<String>,
+                          configuration: TextEditorConfiguration = TextEditorConfiguration(),
+                          validationRules: [ValidationRule<String>] = [],
+                          viewConfigurator: ((UITextField) -> Void)? = nil)
+        -> EditableTextElement<UITextFieldTextEditorAdapter<UITextField>> {
+            return EditableTextElement(
+                value: value,
+                configuration: configuration,
+                validationRules: validationRules,
+                viewConfigurator: viewConfigurator
+            )
+    }
+
+    /**
+     Creates an editable text element that renders a `UITextView`
+
+     - parameter value:            The string value to bind to the text view
+     - parameter configuration:    Configuration options for the text view
+     - parameter validationRules:  Rules used to validate the string value
+     - parameter viewConfigurator: An optional block used to perform additional
+     customization of the text view.
+
+     - returns: An editable text element
+     */
+    public static func textView(value: FormValue<String>,
+                         configuration: TextEditorConfiguration = TextEditorConfiguration(returnKeyAction: .none),
+                         validationRules: [ValidationRule<String>] = [],
+                         viewConfigurator: ((PlaceholderTextView) -> Void)? = nil)
+        -> EditableTextElement<UITextViewTextEditorAdapter<PlaceholderTextView>> {
+            return EditableTextElement(
+                value: value,
+                configuration: configuration,
+                validationRules: validationRules,
+                viewConfigurator: viewConfigurator
+            )
+    }
+
+    /**
+     Creates a "float label" (http://bradfrost.com/blog/post/float-label-pattern/)
+     that uses an adapter typed by `InnerAdapterType` to render the editor view.
+
+     - parameter name:             The field name to display on the float label
+     - parameter configuration:    Configuration options for the text field
+     - parameter validationRules:  Rules used to validate the string value
+     - parameter viewConfigurator: An optional block used to perform additional
+     customization of the float label
+
+     - returns: An editable text elemen
+     */
+    public static func floatLabel
+        <InnerAdapterType>
+        (name: String,
+         value: FormValue<String>,
+         configuration: TextEditorConfiguration = TextEditorConfiguration(),
+         validationRules: [ValidationRule<String>] = [],
+         viewConfigurator: ((FloatLabel<InnerAdapterType>) -> Void)? = nil)
+        -> EditableTextElement<FloatLabelTextEditorAdapter<InnerAdapterType>> {
+            return EditableTextElement(value: value,
+                                       configuration: configuration,
+                                       validationRules: validationRules) {
+                                        $0.setFieldName(name)
+                                        viewConfigurator?($0)
+                                        $0.recomputeMinimumHeight()
+            }
+    }
+
+    /**
+     Creates a "float label" (http://bradfrost.com/blog/post/float-label-pattern/)
+     that uses a `UITextField` as its editor view for a single editable line of text.
+
+     - parameter name:             The field name to display on the float label
+     - parameter configuration:    Configuration options for the text field
+     - parameter validationRules:  Rules used to validate the string value
+     - parameter viewConfigurator: An optional block used to perform additional
+     customization of the float label
+
+     - returns: An editable text elemen
+     */
+    public static func singleLineFloatLabel(name: String,
+                                     value: FormValue<String>,
+                                     configuration: TextEditorConfiguration = TextEditorConfiguration(),
+                                     validationRules: [ValidationRule<String>] = [],
+                                     viewConfigurator: ((FloatLabel<UITextFieldTextEditorAdapter<FloatLabelTextField>>) -> Void)? = nil)
+        -> EditableTextElement<FloatLabelTextEditorAdapter<UITextFieldTextEditorAdapter<FloatLabelTextField>>> {
+            return floatLabel(
+                name: name,
+                value: value,
+                configuration: configuration,
+                validationRules: validationRules,
+                viewConfigurator: viewConfigurator
+            )
+    }
+
+    /**
+     Creates a "float label" (http://bradfrost.com/blog/post/float-label-pattern/)
+     that uses a `UITextView` as its editor view for multiple editable lines
+     of text
+
+     - parameter name:             The field name to display on the float label
+     - parameter configuration:    Configuration options for the text field
+     - parameter validationRules:  Rules used to validate the string value
+     - parameter viewConfigurator: An optional block used to perform additional
+     customization of the float label
+
+     - returns: An editable text element
+     */
+    public static func multiLineFloatLabel(name: String,
+                                    value: FormValue<String>,
+                                    configuration: TextEditorConfiguration = TextEditorConfiguration(returnKeyAction: .none),
+                                    validationRules: [ValidationRule<String>] = [],
+                                    viewConfigurator: ((FloatLabel<UITextViewTextEditorAdapter<PlaceholderTextView>>) -> Void)? = nil)
+        -> EditableTextElement<FloatLabelTextEditorAdapter<UITextViewTextEditorAdapter<PlaceholderTextView>>> {
+            return floatLabel(
+                name: name,
+                value: value,
+                configuration: configuration,
+                validationRules: validationRules,
+                viewConfigurator: viewConfigurator
+            )
+    }
+    /**
+     Creates a "float label" (http://bradfrost.com/blog/post/float-label-pattern/)
+     that uses a `UIPickerView` as its editor view
+
+     - parameter name:             The field name to display on the float label
+     - parameter value:            The string value to bind to the text view
+     - parameter items:            The items to display in the picker view
+     - parameter configuration:    Configuration options for the text field
+     - parameter validationRules:  Rules used to validate the string value
+     - parameter viewConfigurator: An optional block used to perform additional
+     customization of the float label
+
+     - returns: An editable text element
+     */
+
+    public static func pickerField<ValueType>(name: String, value: FormValue<ValueType>, items: [PickerValue<ValueType>],
+                                       configuration: TextEditorConfiguration = TextEditorConfiguration(),
+                                       validationRules: [ValidationRule<String>] = [],
+                                       viewConfigurator: ((FloatLabel<UITextFieldTextEditorAdapter<PickerField<ValueType>>>) -> Void)? = nil)
+        -> EditableTextElement<FloatLabelTextEditorAdapter<UITextFieldTextEditorAdapter<PickerField<ValueType>>>> {
+            let valueString = FormValue("")
+            return floatLabel(name: name,
+                              value: valueString,
+                              configuration: configuration,
+                              validationRules: validationRules) {
+                                $0.textEntryView.items = items
+                                let textEntryView = $0.textEntryView
+                                textEntryView?.didSelectPickerValue = { pickerValue in
+                                    valueString.value = pickerValue.title
+                                    value.value = pickerValue.value
+                                }
+                                textEntryView?.items = items
+                                textEntryView?.selectValue(value.value)
+                                $0.adapterCallbacks?.textDidBeginEditing = { adapterType, viewType in
+                                    viewType.updateSelectedValue()
+                                }
+                                $0.adapterCallbacks?.textDidEndEditing = { adapterType, viewType in
+                                    viewType.updateSelectedValue()
+                                }
+                                viewConfigurator?($0)
+            }
+    }
+
+    public static func infoField(title: NSMutableAttributedString, subTitle: NSMutableAttributedString, viewConfigurator: ((UILabel, UILabel) -> Void)? = nil) -> InfoFieldElement {
+        return InfoFieldElement(title: title, subTitle: subTitle, viewConfigurator: viewConfigurator)
+    }
+
+    public static func divider(color: UIColor = .black, height: CGFloat = 1, viewConfigurator: ((UIView) -> Void)? = nil) -> DividerElement {
+        return DividerElement(color: color, height: height, viewConfigurator:  viewConfigurator)
+    }
+
+}
+
 /**
  Creates a form element that displays a control to toggle a boolean value
  Convenience function for initializing a `BooleanElement`

--- a/Formalist/DividerElement.swift
+++ b/Formalist/DividerElement.swift
@@ -32,7 +32,7 @@ public final class DividerElement: FormElement {
         self.viewConfigurator = viewConfigurator
     }
 
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let view = UIView()
         view.backgroundColor = color
         let heightConstraint = NSLayoutConstraint(

--- a/Formalist/EditableTextElement.swift
+++ b/Formalist/EditableTextElement.swift
@@ -42,7 +42,7 @@ public final class EditableTextElement<AdapterType: TextEditorAdapter>: FormElem
     
     // MARK: FormElement
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let view = adapter.createViewWithCallbacks(TextEditorAdapterCallbacks()) { [weak self] (adapter, view) in
             guard let `self` = self else { return }
 

--- a/Formalist/FormElement.swift
+++ b/Formalist/FormElement.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The protocol that all form element classes must conform to
-public protocol FormElement {
+public class FormElement {
     /// Renders the contents of the form as a `UIView`. This process typically
     /// involves the following steps:
     ///     1. Create the view
@@ -19,5 +19,7 @@ public protocol FormElement {
     ///        to the element.
     ///     4. Allow custom configuration using a block that can be optionally
     ///        passed in to the element initializer
-    func render() -> UIView
+    open func render() -> UIView {
+        fatalError("FormElement must be subclassed and subclasses must override render.")
+    }
 }

--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -186,7 +186,7 @@ public final class GroupElement: FormElement, Validatable {
 
     // MARK: FormElement
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         var subviews = [UIView]()
         var responderViews = [UIView]()
         

--- a/Formalist/InfoFieldElement.swift
+++ b/Formalist/InfoFieldElement.swift
@@ -39,7 +39,7 @@ public final class InfoFieldElement: FormElement {
         self.viewConfigurator = viewConfigurator
     }
 
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let titleLabel = UILabel()
         titleLabel.attributedText = title
 

--- a/Formalist/SegmentElement.swift
+++ b/Formalist/SegmentElement.swift
@@ -37,7 +37,7 @@ public final class SegmentElement<ValueType: Equatable>: FormElement {
         self.viewConfigurator = viewConfigurator
     }
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let items = segments.map { $0.content }
         let segmentView = SegmentElementView(title: title, items: items)
         segmentView.segmentedControl.addTarget(

--- a/Formalist/SegueElement.swift
+++ b/Formalist/SegueElement.swift
@@ -39,7 +39,7 @@ public final class SegueElement: FormElement {
         self.action = action
     }
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let view = SegueElementView(icon: icon, title: title, accessoryIcon: accessoryIcon)
         viewConfigurator?(view)
         let tapGestureRecognizer = UITapGestureRecognizer(

--- a/Formalist/SpacerElement.swift
+++ b/Formalist/SpacerElement.swift
@@ -31,7 +31,7 @@ public final class SpacerElement: FormElement {
     
     // MARK: FormElement
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let view = UIView(frame: CGRect.zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         

--- a/Formalist/StaticTextElement.swift
+++ b/Formalist/StaticTextElement.swift
@@ -43,7 +43,7 @@ public final class StaticTextElement: FormElement {
         self.init(value: FormValue(text), viewConfigurator: viewConfigurator)
     }
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         let label = UILabel(frame: CGRect.zero)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0

--- a/Formalist/ViewElement.swift
+++ b/Formalist/ViewElement.swift
@@ -29,7 +29,7 @@ public final class ViewElement<ValueType: Equatable>: FormElement {
         self.viewConfigurator = viewConfigurator
     }
     
-    public func render() -> UIView {
+    public override func render() -> UIView {
         return viewConfigurator(value)
     }
 }

--- a/FormalistTests/EditableTextElementTests.swift
+++ b/FormalistTests/EditableTextElementTests.swift
@@ -17,7 +17,7 @@ class EditableTextElementTests: FBSnapshotTestCase {
     }
     
     @objc func testRenderTextFieldElement() {
-        let element = textField(value: FormValue("Text Field Element")) {
+        let element = FormElement.textField(value: FormValue("Text Field Element")) {
             $0.textColor = .red
             $0.textAlignment = .center
         }
@@ -26,7 +26,7 @@ class EditableTextElementTests: FBSnapshotTestCase {
     }
     
     @objc func testRenderTextViewElement() {
-        let element = textView(value: FormValue("Text View Element")) {
+        let element = FormElement.textView(value: FormValue("Text View Element")) {
             $0.textColor = .red
             $0.textAlignment = .center
         }
@@ -35,32 +35,32 @@ class EditableTextElementTests: FBSnapshotTestCase {
     }
     
     @objc func testRenderSingleLineFloatLabelElementWithEmptyValue() {
-        let element = singleLineFloatLabel(name: "Test", value: FormValue(""))
+        let element = FormElement.singleLineFloatLabel(name: "Test", value: FormValue(""))
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
     }
     
     @objc func testRenderSingleLineFloatLabelElementWithNonEmptyValue() {
-        let element = singleLineFloatLabel(name: "Test", value: FormValue("Quam Amet Fringilla Purus Aenean"))
+        let element = FormElement.singleLineFloatLabel(name: "Test", value: FormValue("Quam Amet Fringilla Purus Aenean"))
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
     }
     
     @objc func testRenderMultiLineFloatLabelElementWithEmptyValue() {
-        let element = multiLineFloatLabel(name: "Test", value: FormValue(""))
+        let element = FormElement.multiLineFloatLabel(name: "Test", value: FormValue(""))
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
     }
     
     @objc func testRenderMultiLineFloatLabelElementWithNonEmptyValue() {
-        let element = multiLineFloatLabel(name: "Test", value: FormValue("Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec ullamcorper nulla non metus auctor fringilla."))
+        let element = FormElement.multiLineFloatLabel(name: "Test", value: FormValue("Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec ullamcorper nulla non metus auctor fringilla."))
         let elementView = renderElementForTesting(element)
         FBSnapshotVerifyView(elementView)
     }
     
     @objc func testUpdateTextFieldByUpdatingValue() {
         let value = FormValue("foo")
-        let element = textField(value: value)
+        let element = FormElement.textField(value: value)
         let elementView = element.render() as! UITextField
         
         value.value = "bar"
@@ -69,7 +69,7 @@ class EditableTextElementTests: FBSnapshotTestCase {
     
     @objc func testUpdateTextViewByUpdatingValue() {
         let value = FormValue("foo")
-        let element = textView(value: value)
+        let element = FormElement.textView(value: value)
         let elementView = element.render() as! UITextView
         
         value.value = "bar"
@@ -78,7 +78,7 @@ class EditableTextElementTests: FBSnapshotTestCase {
     
     @objc func testUpdateSingleLineFloatLabelByUpdatingValue() {
         let value = FormValue("foo")
-        let element = singleLineFloatLabel(name: "Float Label", value: value)
+        let element = FormElement.singleLineFloatLabel(name: "Float Label", value: value)
         let elementView = element.render() as! FloatLabel<UITextFieldTextEditorAdapter<FloatLabelTextField>>
         
         value.value = "bar"
@@ -87,7 +87,7 @@ class EditableTextElementTests: FBSnapshotTestCase {
     
     @objc func testUpdateMultiLineFloatLabelByUpdatingValue() {
         let value = FormValue("foo")
-        let element = multiLineFloatLabel(name: "Float Label", value: value)
+        let element = FormElement.multiLineFloatLabel(name: "Float Label", value: value)
         let elementView = element.render() as! FloatLabel<UITextViewTextEditorAdapter<PlaceholderTextView>>
         
         value.value = "bar"

--- a/FormalistTests/GroupElementTests.swift
+++ b/FormalistTests/GroupElementTests.swift
@@ -18,7 +18,7 @@ class GroupElementTests: FBSnapshotTestCase {
         super.setUp()
         recordMode = false
         
-        validatableElement = textField(value: FormValue("<invalid>"), validationRules: [.email]) { textField in
+        validatableElement = .textField(value: FormValue("<invalid>"), validationRules: [.email]) { textField in
             textField.placeholder = "Text Element 1"
         }
         childElements = [

--- a/FormalistTests/StaticTextElementTests.swift
+++ b/FormalistTests/StaticTextElementTests.swift
@@ -17,7 +17,7 @@ class StaticTextElementTests: FBSnapshotTestCase {
     }
     
     @objc func testRender() {
-        let element = staticText("Static Text Element") {
+        let element = FormElement.staticText("Static Text Element") {
             $0.textAlignment = .center
             $0.textColor = .red
         }
@@ -27,7 +27,7 @@ class StaticTextElementTests: FBSnapshotTestCase {
     
     @objc func testUpdateViewByUpdatingValue() {
         let value = FormValue("foo")
-        let element = staticText(value)
+        let element = FormElement.staticText(value)
         let elementView = element.render() as! UILabel
         
         value.value = "bar"


### PR DESCRIPTION
Make `FormElement`s more discoverable by making them static functions on the `FormElement` type. This allows Xcode to offer suggestions for `FormElement`s when someone types `FormElement.` or `FormElement.group([.`

To accomplish this `FormElement` had to be changed from a `protocol` to a class intended for subclassing. This is because in Swift static members on a protocol can only be accessed through an implementation of the protocol. This would defeat the purpose because then users would have to type `BooleanElement.` and Xcode would suggest the `boolean` static function. 