### PR TITLE
Allow customization of 'done' button title

### DIFF
--- a/Formalist/AccessoryViewToolbar.swift
+++ b/Formalist/AccessoryViewToolbar.swift
@@ -21,11 +21,10 @@ class AccessoryViewToolbar: UIToolbar {
         return UIBarButtonItem(title: "Next", style: .plain, target: self, action: #selector(nextAction))
     }()
 
-    private func doneButtonItem(customTitled title:String? = nil) -> UIBarButtonItem {
+    private func doneButtonItem(withCustomTitle title:String? = nil) -> UIBarButtonItem {
         if let title = title {
             return UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(done))
         } else {
-
             return UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
         }
     }
@@ -38,7 +37,7 @@ class AccessoryViewToolbar: UIToolbar {
         items = [
             nextButtonItem,
             UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            doneButtonItem(customTitled: doneButtonCustomTitle)
+            doneButtonItem(withCustomTitle: doneButtonCustomTitle)
         ]
     }
     

--- a/Formalist/AccessoryViewToolbar.swift
+++ b/Formalist/AccessoryViewToolbar.swift
@@ -21,19 +21,24 @@ class AccessoryViewToolbar: UIToolbar {
         return UIBarButtonItem(title: "Next", style: .plain, target: self, action: #selector(nextAction))
     }()
 
-    lazy var doneButtonItem: UIBarButtonItem = {
-        return UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
-    }()
+    private func doneButtonItem(customTitled title:String? = nil) -> UIBarButtonItem {
+        if let title = title {
+            return UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(done))
+        } else {
+
+            return UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
+        }
+    }
 
     var callbacks: AccessoryViewToolbarCallbacks?
 
-    override init(frame: CGRect) {
+    init(frame: CGRect, doneButtonCustomTitle: String? = nil) {
         super.init(frame: frame)
 
         items = [
             nextButtonItem,
             UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            doneButtonItem
+            doneButtonItem(customTitled: doneButtonCustomTitle)
         ]
     }
     

--- a/Formalist/TextEditorConfiguration.swift
+++ b/Formalist/TextEditorConfiguration.swift
@@ -28,7 +28,7 @@ public struct TextEditorConfiguration {
 
     public enum DoneButtonStyle {
         case custom(title: String)
-        case builtIn
+        case `default`
     }
 
     public let returnKeyAction: ReturnKeyAction
@@ -44,7 +44,7 @@ public struct TextEditorConfiguration {
         switch doneButtonStyle {
         case .custom(let title):
             return title
-        case .builtIn:
+        case .default:
             return nil
         }
     }
@@ -72,7 +72,7 @@ public struct TextEditorConfiguration {
         shouldResignFirstResponderWhenFinished: Bool = true,
         showAccessoryViewToolbar: Bool = false,
         formatter: Formattable? = nil,
-        doneButtonStyle: DoneButtonStyle = .builtIn,
+        doneButtonStyle: DoneButtonStyle = .default,
         textEditorAction: ((TextEditorAction) -> Void)? = nil
     ) {
         self.returnKeyAction = returnKeyAction

--- a/Formalist/TextEditorConfiguration.swift
+++ b/Formalist/TextEditorConfiguration.swift
@@ -26,6 +26,11 @@ public struct TextEditorConfiguration {
         case returnKey
     }
 
+    public enum DoneButtonStyle {
+        case custom(title: String)
+        case builtIn
+    }
+
     public let returnKeyAction: ReturnKeyAction
     public let continuouslyUpdatesValue: Bool
     public let maximumLength: Int?
@@ -33,6 +38,16 @@ public struct TextEditorConfiguration {
     public let showAccessoryViewToolbar: Bool
     public let textEditorAction: ((TextEditorAction) -> Void)?
     public let formatter: Formattable?
+
+    private let doneButtonStyle: DoneButtonStyle
+    public var doneButtonCustomTitle: String? {
+        switch doneButtonStyle {
+        case .custom(let title):
+            return title
+        case .builtIn:
+            return nil
+        }
+    }
 
     /**
      Designated initializer
@@ -45,6 +60,8 @@ public struct TextEditorConfiguration {
      the text is finished editing
      - parameter maximumLength:            The maximum text length
      to restrict text input to
+     - parameter doneButtonStyle:          The customization point
+     for the button associated with the `done` `TextEditorAction`
 
      - returns: An initialized instance of the receiver
      */
@@ -55,6 +72,7 @@ public struct TextEditorConfiguration {
         shouldResignFirstResponderWhenFinished: Bool = true,
         showAccessoryViewToolbar: Bool = false,
         formatter: Formattable? = nil,
+        doneButtonStyle: DoneButtonStyle = .builtIn,
         textEditorAction: ((TextEditorAction) -> Void)? = nil
     ) {
         self.returnKeyAction = returnKeyAction
@@ -63,6 +81,7 @@ public struct TextEditorConfiguration {
         self.shouldResignFirstResponderWhenFinished = shouldResignFirstResponderWhenFinished
         self.showAccessoryViewToolbar = showAccessoryViewToolbar
         self.formatter = formatter
+        self.doneButtonStyle = doneButtonStyle
         self.textEditorAction = textEditorAction
     }
 }

--- a/Formalist/UITextFieldTextEditorAdapter.swift
+++ b/Formalist/UITextFieldTextEditorAdapter.swift
@@ -148,7 +148,8 @@ private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UIT
             textField?.resignFirstResponder()
             self?.configuration.textEditorAction?(.done)
         }
-        let toolbar = AccessoryViewToolbar(frame: .zero)
+
+        let toolbar = AccessoryViewToolbar(frame: .zero, doneButtonCustomTitle: configuration.doneButtonCustomTitle)
         toolbar.sizeToFit()
         toolbar.callbacks = callbacks
         textField.inputAccessoryView = toolbar


### PR DESCRIPTION
Some actions associated with the `done` button may be more clearly represented with different text; this allows users to specify a more descriptive title when needed.