### PR TITLE
Make extension methods public

### DIFF
--- a/Formalist/Convenience.swift
+++ b/Formalist/Convenience.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Seed Platform, Inc. All rights reserved.
 //
 
-extension FormElement {
+public extension FormElement {
     /**
      Creates a form element that displays a control to toggle a boolean value
      Convenience function for initializing a `BooleanElement`


### PR DESCRIPTION
The project using this framework couldn't see the new extension methods; this makes sure they're available.