### PR TITLE
Allow subclassing of FormViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased]
 
+## Changed
+
+- Allow `FormViewController` to be subclassed ([@klaaspieter])
+
 # [0.4.1]
 
 ## Added

--- a/Example/FormViewController.swift
+++ b/Example/FormViewController.swift
@@ -1,0 +1,28 @@
+import Formalist
+
+class FormViewController: Formalist.FormViewController {
+    init() {
+        super.init(
+            elements: [
+                .inset(.init(top: 15, left: 15, bottom: 15, right: 15), elements: [
+                    .staticText(
+                        "This is an example of a Formalist.FormViewController subclass",
+                        viewConfigurator: {
+                            $0.textAlignment = .center
+                            $0.font = .preferredFont(forTextStyle: .footnote)
+                        }
+                    ),
+                ]),
+            ]
+        )
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+    }
+}

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    fileprivate lazy var formViewController: FormViewController = {
+    fileprivate lazy var formViewController: Formalist.FormViewController = {
         let edgeInsets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
 
         let numberFormatter = FormNumberFormatter(
@@ -43,7 +43,7 @@ class ViewController: UIViewController {
         groupedConfiguration.style = .grouped(backgroundColor: .white)
         groupedConfiguration.layout.edgeInsets = edgeInsets
         
-        return FormViewController(elements: [
+        return Formalist.FormViewController(elements: [
             .inset(edgeInsets, elements: [
                 .staticText("Welcome to the Formalist Catalog app. This text is an example of a StaticTextElement. Other kinds of elements are showcased below.") {
                     $0.textAlignment = .center
@@ -98,7 +98,10 @@ class ViewController: UIViewController {
                 .segue(icon: UIImage(named: "circle")!, title: "Segue Element", viewConfigurator: {
                     $0.accessibilityIdentifier = "segueView"
                 }) { [unowned self] in
-                    self.displayAlertWithTitle("Segue Element", message: "Tapped the element.")
+                    self.navigationController?.pushViewController(
+                        FormViewController(),
+                        animated: true
+                    )
                 },
             ]),
             .inset(edgeInsets, elements: [

--- a/Formalist.xcodeproj/project.pbxproj
+++ b/Formalist.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		A15176551E16760100E5CCBC /* InfoFieldElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15176541E16760100E5CCBC /* InfoFieldElement.swift */; };
 		A151765D1E16763200E5CCBC /* DividerElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A151765C1E16763200E5CCBC /* DividerElement.swift */; };
 		A151765F1E1676E100E5CCBC /* AccessoryViewToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A151765E1E1676E100E5CCBC /* AccessoryViewToolbar.swift */; };
+		A1F1FEDE2008C91D00BA48F2 /* FormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F1FEDD2008C91D00BA48F2 /* FormViewController.swift */; };
 		BF2209BE1FC6379600CAFE89 /* Formalist.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7285A7061D17CB7000718D23 /* Formalist.framework */; };
 		BF2209C01FC637A500CAFE89 /* Formalist.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7285A7061D17CB7000718D23 /* Formalist.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BF9631B31FC62DEE00D7362F /* Formalist.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7285A7061D17CB7000718D23 /* Formalist.framework */; };
@@ -194,6 +195,7 @@
 		A151765E1E1676E100E5CCBC /* AccessoryViewToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessoryViewToolbar.swift; sourceTree = "<group>"; };
 		A19CF9111FB5DFA200BB1E86 /* FBSnapshotTestCase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSnapshotTestCase.framework; path = Carthage/Build/iOS/FBSnapshotTestCase.framework; sourceTree = "<group>"; };
 		A1A486B51FB5E224008979D6 /* StackViewController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StackViewController.framework; path = Carthage/Build/iOS/StackViewController.framework; sourceTree = "<group>"; };
+		A1F1FEDD2008C91D00BA48F2 /* FormViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewController.swift; sourceTree = "<group>"; };
 		BF9631981FC629E700D7362F /* StackViewController.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = StackViewController.framework.dSYM; path = Carthage/Build/iOS/StackViewController.framework.dSYM; sourceTree = "<group>"; };
 		BF9631991FC629E700D7362F /* FBSnapshotTestCase.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = FBSnapshotTestCase.framework.dSYM; path = Carthage/Build/iOS/FBSnapshotTestCase.framework.dSYM; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -290,6 +292,7 @@
 				7285A7AB1D17CCC300718D23 /* Assets.xcassets */,
 				7285A7AD1D17CCC300718D23 /* LaunchScreen.storyboard */,
 				7285A7B01D17CCC300718D23 /* Info.plist */,
+				A1F1FEDD2008C91D00BA48F2 /* FormViewController.swift */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -675,6 +678,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1F1FEDE2008C91D00BA48F2 /* FormViewController.swift in Sources */,
 				7285A7A71D17CCC300718D23 /* ViewController.swift in Sources */,
 				7285A7A51D17CCC300718D23 /* AppDelegate.swift in Sources */,
 			);

--- a/Formalist/FormViewController.swift
+++ b/Formalist/FormViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import StackViewController
 
 /// A view controller that displays and manages a set of form elements
-public final class FormViewController: UIViewController {
+open class FormViewController: UIViewController {
     fileprivate let rootElement: FormElement
     fileprivate lazy var autoscrollView = AutoScrollView(frame: CGRect.zero)
     
@@ -51,11 +51,11 @@ public final class FormViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func loadView() {
+    open override func loadView() {
         view = autoscrollView
     }
     
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
         reload()
     }
@@ -63,7 +63,7 @@ public final class FormViewController: UIViewController {
     // MARK: API
     
     /// Reloads the view by re-rendering the entire tree of form elements
-    public func reload() {
+    open func reload() {
         let rootElementView = rootElement.render()
         rootElementView.translatesAutoresizingMaskIntoConstraints = false
         
@@ -81,7 +81,7 @@ public final class FormViewController: UIViewController {
      - parameter completionHandler: The completion handler to call when
      validation succeeds, fails, or is cancelled.
      */
-    public func validate(_ completionHandler: @escaping (ValidationResult) -> Void) {
+    open func validate(_ completionHandler: @escaping (ValidationResult) -> Void) {
         if let validatableElement = rootElement as? Validatable {
             validatableElement.validateAndStoreResult { result in
                 self.reload()

--- a/Formalist/FormViewController.swift
+++ b/Formalist/FormViewController.swift
@@ -43,8 +43,9 @@ open class FormViewController: UIViewController {
      
      - returns: An initialized instance of the receiver
      */
-    public convenience init(elements: [FormElement]) {
-        self.init(rootElement: GroupElement(elements: elements))
+    public init(elements: [FormElement]) {
+        self.rootElement = GroupElement(elements: elements)
+        super.init(nibName: nil, bundle: nil)
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/FormalistUITests/FormalistUITests.swift
+++ b/FormalistUITests/FormalistUITests.swift
@@ -95,7 +95,7 @@ class FormalistUITests: XCTestCase {
     func testSegueElement() {
         let app = XCUIApplication()
         app.scrollViews.otherElements.staticTexts["Segue Element"].tap()
-        app.alerts.buttons["Dismiss"].tap()
+        XCTAssertTrue(app.navigationBars["Example"].buttons["Example"].exists)
     }
     
     func testValidation() {


### PR DESCRIPTION
Allow `FormViewController` to be subclassed so that forms that take up the entire available space of a view controller's view don't have to do the `addChildViewController` dance. Subclasses can set up their own forms by calling the superclass' `init(elements:)` or `init(rootElement)` designated initializers.

This also updates the example project with an example of a subclassed `FormViewController`.