### PR TITLE
Swift 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changed
 
 - Allow `FormViewController` to be subclassed ([@klaaspieter])
+- Update to Swift 4.1 ([@klaaspieter])
 
 # [0.4.1]
 

--- a/Formalist.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Formalist.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -251,7 +251,7 @@ public final class GroupElement: FormElement, Validatable {
     // MARK: Validatable
     
     public func validate(_ completionHandler: @escaping (ValidationResult) -> Void) {
-        let validatables = elements.flatMap { $0 as? Validatable }
+        let validatables = elements.compactMap { $0 as? Validatable }
         validateObjects(validatables, completionHandler: completionHandler)
     }
     


### PR DESCRIPTION
Updates a single deprecated use of `flatMap` to use `compactMap` instead.