### PR TITLE
Support accessory toolbar for multiline float labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Added
 
 - Customization of `done` button title ([@lsavino])
+- Support for showing accessory toolbar with `multiLineFloatLabel` ([@klaaspieter])
 
 # [0.4.0]
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -56,7 +56,11 @@ class ViewController: UIViewController {
                     $0.placeholder = "Text View Element"
                     $0.accessibilityIdentifier = "textView"
                 },
-                .singleLineFloatLabel(name: "Float Label Element", value: self.floatLabelValue) {
+                .singleLineFloatLabel(
+                    name: "Float Label Element",
+                    value: self.floatLabelValue,
+                    configuration: TextEditorConfiguration(showAccessoryViewToolbar: true)
+                ) {
                     $0.textEntryView.accessibilityIdentifier = "floatLabel"
                 },
                 .multiLineFloatLabel(name: "Float MultiLine Element", value: self.multiLineFloatLabelValue) {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -63,7 +63,11 @@ class ViewController: UIViewController {
                 ) {
                     $0.textEntryView.accessibilityIdentifier = "floatLabel"
                 },
-                .multiLineFloatLabel(name: "Float MultiLine Element", value: self.multiLineFloatLabelValue) {
+                .multiLineFloatLabel(
+                    name: "Float MultiLine Element",
+                    value: self.multiLineFloatLabelValue,
+                    configuration: TextEditorConfiguration(showAccessoryViewToolbar: true)
+                ) {
                     $0.textEntryView.accessibilityIdentifier = "multiLineFloatLabel"
                 },
                 .pickerField(name: "Picker Field Element", value: self.pickerFieldValue, items: [

--- a/Formalist.xcodeproj/project.pbxproj
+++ b/Formalist.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		BF9631B91FC6301100D7362F /* StackViewController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1A486B51FB5E224008979D6 /* StackViewController.framework */; };
 		BF9631BA1FC6302A00D7362F /* StackViewController.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = A1A486B51FB5E224008979D6 /* StackViewController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BF9631BB1FC6302A00D7362F /* FBSnapshotTestCase.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = A19CF9111FB5DFA200BB1E86 /* FBSnapshotTestCase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EBB9607C20BC51DD00AC12FF /* TextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB9607B20BC51DD00AC12FF /* TextEditor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -198,6 +199,7 @@
 		A1F1FEDD2008C91D00BA48F2 /* FormViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewController.swift; sourceTree = "<group>"; };
 		BF9631981FC629E700D7362F /* StackViewController.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = StackViewController.framework.dSYM; path = Carthage/Build/iOS/StackViewController.framework.dSYM; sourceTree = "<group>"; };
 		BF9631991FC629E700D7362F /* FBSnapshotTestCase.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = FBSnapshotTestCase.framework.dSYM; path = Carthage/Build/iOS/FBSnapshotTestCase.framework.dSYM; sourceTree = "<group>"; };
+		EBB9607B20BC51DD00AC12FF /* TextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -376,6 +378,7 @@
 				A151765E1E1676E100E5CCBC /* AccessoryViewToolbar.swift */,
 				7285A7221D17CBCA00718D23 /* Box.swift */,
 				7285A73C1D17CBCA00718D23 /* WeakBox.swift */,
+				EBB9607B20BC51DD00AC12FF /* TextEditor.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -633,6 +636,7 @@
 				7285A7421D17CBCA00718D23 /* FloatLabel.swift in Sources */,
 				7285A7511D17CBCA00718D23 /* TextEditorConfiguration.swift in Sources */,
 				7285A74F1D17CBCA00718D23 /* StaticTextElement.swift in Sources */,
+				EBB9607C20BC51DD00AC12FF /* TextEditor.swift in Sources */,
 				7285A7521D17CBCA00718D23 /* UITextFieldTextEditorAdapter.swift in Sources */,
 				7285A73F1D17CBCA00718D23 /* Box.swift in Sources */,
 				7285A74E1D17CBCA00718D23 /* SpacerElement.swift in Sources */,

--- a/Formalist/TextEditor.swift
+++ b/Formalist/TextEditor.swift
@@ -6,6 +6,8 @@ protocol TextEditor: class {
     var inputAccessoryView: UIView? { get set }
 
     @discardableResult func resignFirstResponder() -> Bool
+
+    func reloadInputViews()
 }
 
 extension UITextField: TextEditor {}
@@ -28,6 +30,7 @@ func presentToolbar(with editor: TextEditor, configuration: TextEditorConfigurat
     )
     toolbar.sizeToFit()
     editor.inputAccessoryView = toolbar
+    editor.reloadInputViews()
 
     // Hide next button when nextFormResponder == nil.
     if editor.nextFormResponder == nil {

--- a/Formalist/TextEditor.swift
+++ b/Formalist/TextEditor.swift
@@ -8,6 +8,9 @@ protocol TextEditor: class {
     @discardableResult func resignFirstResponder() -> Bool
 }
 
+extension UITextField: TextEditor {}
+extension UITextView: TextEditor {}
+
 func presentToolbar(with editor: TextEditor, configuration: TextEditorConfiguration) {
     let toolbar = AccessoryViewToolbar(
         frame: .zero,

--- a/Formalist/TextEditor.swift
+++ b/Formalist/TextEditor.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+protocol TextEditor: class {
+    var nextFormResponder: UIView? { get }
+
+    var inputAccessoryView: UIView? { get set }
+
+    @discardableResult func resignFirstResponder() -> Bool
+}
+
+func presentToolbar(with editor: TextEditor, configuration: TextEditorConfiguration) {
+    let toolbar = AccessoryViewToolbar(
+        frame: .zero,
+        doneButtonCustomTitle: configuration.doneButtonCustomTitle
+    )
+    toolbar.callbacks = AccessoryViewToolbarCallbacks(
+        nextAction: { [weak editor] in
+            editor?.nextFormResponder?.becomeFirstResponder()
+            configuration.textEditorAction?(.next)
+        },
+        doneAction: { [weak editor] in
+            editor?.resignFirstResponder()
+            configuration.textEditorAction?(.done)
+        }
+    )
+    toolbar.sizeToFit()
+    editor.inputAccessoryView = toolbar
+
+    // Hide next button when nextFormResponder == nil.
+    if editor.nextFormResponder == nil {
+        toolbar.nextButtonItem.isEnabled = false
+        toolbar.nextButtonItem.title = ""
+    }
+}

--- a/Formalist/UITextFieldTextEditorAdapter.swift
+++ b/Formalist/UITextFieldTextEditorAdapter.swift
@@ -85,7 +85,7 @@ private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UIT
         callbacks.textDidBeginEditing?(adapter, textField)
 
         if configuration.showAccessoryViewToolbar {
-            appendToolbar(toTextField: textField)
+            presentToolbar(with: textField, configuration: configuration)
         }
     }
     
@@ -135,29 +135,6 @@ private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UIT
                 }
             }
             return false
-        }
-    }
-
-    private func appendToolbar(toTextField textField: TextFieldType) {
-        var callbacks = AccessoryViewToolbarCallbacks()
-        callbacks.nextAction = { [weak self, weak textField] in
-            textField?.nextFormResponder?.becomeFirstResponder()
-            self?.configuration.textEditorAction?(.next)
-        }
-        callbacks.doneAction = { [weak self, weak textField] in
-            textField?.resignFirstResponder()
-            self?.configuration.textEditorAction?(.done)
-        }
-
-        let toolbar = AccessoryViewToolbar(frame: .zero, doneButtonCustomTitle: configuration.doneButtonCustomTitle)
-        toolbar.sizeToFit()
-        toolbar.callbacks = callbacks
-        textField.inputAccessoryView = toolbar
-
-        //Hide next button when nextFormResponder == nil.
-        if textField.nextFormResponder == nil {
-            toolbar.nextButtonItem.isEnabled = false
-            toolbar.nextButtonItem.title = ""
         }
     }
 }

--- a/Formalist/UITextViewTextEditorAdapter.swift
+++ b/Formalist/UITextViewTextEditorAdapter.swift
@@ -73,6 +73,10 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
             fatalError("Expected text view of type \(TextViewType.self)")
         }
         callbacks.textDidBeginEditing?(adapter, textView)
+
+        if configuration.showAccessoryViewToolbar {
+            appendToolbar(toTextView: textView)
+        }
     }
     
     @objc fileprivate func textViewDidEndEditing(_ textView: UITextView) {
@@ -115,4 +119,28 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
             return true
         }
     }
+
+    private func appendToolbar(toTextView textView: TextViewType) {
+        var callbacks = AccessoryViewToolbarCallbacks()
+        callbacks.nextAction = { [weak self, weak textView] in
+            textView?.nextFormResponder?.becomeFirstResponder()
+            self?.configuration.textEditorAction?(.next)
+        }
+        callbacks.doneAction = { [weak self, weak textView] in
+            textView?.resignFirstResponder()
+            self?.configuration.textEditorAction?(.done)
+        }
+
+        let toolbar = AccessoryViewToolbar(frame: .zero, doneButtonCustomTitle: configuration.doneButtonCustomTitle)
+        toolbar.sizeToFit()
+        toolbar.callbacks = callbacks
+        textView.inputAccessoryView = toolbar
+
+        //Hide next button when nextFormResponder == nil.
+        if textView.nextFormResponder == nil {
+            toolbar.nextButtonItem.isEnabled = false
+            toolbar.nextButtonItem.title = ""
+        }
+    }
+
 }

--- a/Formalist/UITextViewTextEditorAdapter.swift
+++ b/Formalist/UITextViewTextEditorAdapter.swift
@@ -75,7 +75,7 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
         callbacks.textDidBeginEditing?(adapter, textView)
 
         if configuration.showAccessoryViewToolbar {
-            appendToolbar(toTextView: textView)
+            presentToolbar(with: textView, configuration: configuration)
         }
     }
     
@@ -119,29 +119,4 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
             return true
         }
     }
-
-    private func appendToolbar(toTextView textView: TextViewType) {
-        var callbacks = AccessoryViewToolbarCallbacks()
-        callbacks.nextAction = { [weak self, weak textView] in
-            textView?.nextFormResponder?.becomeFirstResponder()
-            self?.configuration.textEditorAction?(.next)
-        }
-        callbacks.doneAction = { [weak self, weak textView] in
-            textView?.resignFirstResponder()
-            self?.configuration.textEditorAction?(.done)
-        }
-
-        let toolbar = AccessoryViewToolbar(frame: .zero, doneButtonCustomTitle: configuration.doneButtonCustomTitle)
-        toolbar.callbacks = callbacks
-        toolbar.sizeToFit()
-        textView.inputAccessoryView = toolbar
-        textView.reloadInputViews()
-
-        //Hide next button when nextFormResponder == nil.
-        if textView.nextFormResponder == nil {
-            toolbar.nextButtonItem.isEnabled = false
-            toolbar.nextButtonItem.title = ""
-        }
-    }
-
 }

--- a/Formalist/UITextViewTextEditorAdapter.swift
+++ b/Formalist/UITextViewTextEditorAdapter.swift
@@ -132,9 +132,10 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
         }
 
         let toolbar = AccessoryViewToolbar(frame: .zero, doneButtonCustomTitle: configuration.doneButtonCustomTitle)
-        toolbar.sizeToFit()
         toolbar.callbacks = callbacks
+        toolbar.sizeToFit()
         textView.inputAccessoryView = toolbar
+        textView.reloadInputViews()
 
         //Hide next button when nextFormResponder == nil.
         if textView.nextFormResponder == nil {


### PR DESCRIPTION
Change UITextViewTextEditorAdapter to honor `TextEditorConfiguration.showAccessoryViewToolbar`. If it's set to `true` the adapter will now show the toolbar when the text view becomes first responder.