### PR TITLE
Linking all responder views within a GroupElement (including nested ones)

### DIFF
--- a/Formalist.podspec
+++ b/Formalist.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "Formalist"
-    s.version = "0.6.0"
+    s.version = "0.6.1"
     s.license = { type: "MIT" }
     s.homepage = "https://github.com/seedco/Formalist"
     s.author = "Seed"


### PR DESCRIPTION
This will allow the "Next" button to jump across groups.