### PR TITLE
Reverted changes for PR #75 and reimplements it w/out breaking the group insets.

### DIFF
--- a/Formalist.podspec
+++ b/Formalist.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "Formalist"
-    s.version = "0.6.1"
+    s.version = "0.6.2"
     s.license = { type: "MIT" }
     s.homepage = "https://github.com/seedco/Formalist"
     s.author = "Seed"

--- a/Formalist/FloatLabel.swift
+++ b/Formalist/FloatLabel.swift
@@ -70,12 +70,6 @@ open class FloatLabel<AdapterType: TextEditorAdapter>: UIView, CAAnimationDelega
     /// a text editing event.
     open var adapterCallbacks: TextEditorAdapterCallbacks<AdapterType>?
 
-    @objc open override var nextFormResponder: UIView? {
-        didSet {
-            textEntryView.nextFormResponder = self.nextFormResponder
-        }
-    }
-
     public typealias TextChangedObserver = (AdapterType, AdapterType.ViewType) -> Void
     
     /// Callback to call when the text in the text entry view is changed

--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -184,8 +184,6 @@ public final class GroupElement: FormElement, Validatable {
         self.init(configuration: configuration, elements: elements)
     }
 
-    private var responderViewsFromLastRender: [UIView] = []
-
     // MARK: FormElement
     
     public override func render() -> UIView {
@@ -207,11 +205,6 @@ public final class GroupElement: FormElement, Validatable {
                     lastResponderView.nextFormResponder = elementView
                 }
                 responderViews.append(elementView)
-            }
-
-            if let groupElement = element as? GroupElement {
-                // Grab any nested responder views and pull them up to this group's level.
-                responderViews.append(contentsOf: groupElement.responderViewsFromLastRender)
             }
 
             if !(element is GroupElement),
@@ -237,7 +230,6 @@ public final class GroupElement: FormElement, Validatable {
             addSeparator(isBorder: true)
         }
 
-        responderViewsFromLastRender = responderViews
         return createContainerWithSubviews(subviews, responderViews: responderViews)
     }
     
@@ -276,18 +268,19 @@ public final class GroupElement: FormElement, Validatable {
         required init?(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-        
+
+        @objc open override var nextFormResponder: UIView? {
+            didSet {
+                initialFormResponderView?.nextFormResponder = nextFormResponder
+            }
+        }
+
         fileprivate override var canBecomeFirstResponder : Bool {
-            return true
+          initialFormResponderView?.canBecomeFirstResponder ?? false
         }
         
         fileprivate override func becomeFirstResponder() -> Bool {
-            var responderView = nextFormResponder
-            while let containerView = responderView as? ContainerView {
-                responderView = containerView.initialFormResponderView
-            }
-            responderView?.becomeFirstResponder()
-            return false
+          initialFormResponderView?.becomeFirstResponder() ?? false
         }
     }
 }

--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -191,13 +191,13 @@ public final class GroupElement: FormElement, Validatable {
     public override func render() -> UIView {
         var subviews = [UIView]()
         var responderViews = [UIView]()
-
+        
         func addSeparator(isBorder: Bool) {
             if let separatorView = configuration.createSeparatorWithBorder(isBorder) {
                 subviews.append(separatorView)
             }
         }
-
+        
         func addChildElement(_ element: FormElement) -> Bool {
             let elementView = element.render()
             subviews.append(configuration.arrangedSubviewForElementView(elementView))
@@ -215,10 +215,10 @@ public final class GroupElement: FormElement, Validatable {
             }
 
             if !(element is GroupElement),
-                let validationResult = (element as? Validatable)?.validationResult,
-                case let .invalid(message) = validationResult,
-                let errorView = configuration.createValidationErrorViewWithMessage(message) {
-
+               let validationResult = (element as? Validatable)?.validationResult,
+               case let .invalid(message) = validationResult,
+               let errorView = configuration.createValidationErrorViewWithMessage(message) {
+                
                 addSeparator(isBorder: true)
                 subviews.append(errorView)
                 return false

--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -210,6 +210,7 @@ public final class GroupElement: FormElement, Validatable {
             }
 
             if let groupElement = element as? GroupElement {
+                // Grab any nested responder views and pull them up to this group's level.
                 responderViews.append(contentsOf: groupElement.responderViewsFromLastRender)
             }
 

--- a/Formalist/GroupElement.swift
+++ b/Formalist/GroupElement.swift
@@ -269,12 +269,6 @@ public final class GroupElement: FormElement, Validatable {
             fatalError("init(coder:) has not been implemented")
         }
 
-        @objc open override var nextFormResponder: UIView? {
-            didSet {
-                initialFormResponderView?.nextFormResponder = nextFormResponder
-            }
-        }
-
         fileprivate override var canBecomeFirstResponder : Bool {
           initialFormResponderView?.canBecomeFirstResponder ?? false
         }

--- a/Formalist/TextEditor.swift
+++ b/Formalist/TextEditor.swift
@@ -1,11 +1,7 @@
 import UIKit
 
-protocol TextEditor: class {
-    var nextFormResponder: UIView? { get }
-
+protocol TextEditor: UIView {
     var inputAccessoryView: UIView? { get set }
-
-    @discardableResult func resignFirstResponder() -> Bool
 
     func reloadInputViews()
 }
@@ -20,7 +16,7 @@ func presentToolbar(with editor: TextEditor, configuration: TextEditorConfigurat
     )
     toolbar.callbacks = AccessoryViewToolbarCallbacks(
         nextAction: { [weak editor] in
-            editor?.nextFormResponder?.becomeFirstResponder()
+            editor?.resolvedNextFormResponder?.becomeFirstResponder()
             configuration.textEditorAction?(.next)
         },
         doneAction: { [weak editor] in
@@ -32,8 +28,8 @@ func presentToolbar(with editor: TextEditor, configuration: TextEditorConfigurat
     editor.inputAccessoryView = toolbar
     editor.reloadInputViews()
 
-    // Hide next button when nextFormResponder == nil.
-    if editor.nextFormResponder == nil {
+    // Hide next button when resolvedNextFormResponder == nil.
+    if editor.resolvedNextFormResponder == nil {
         toolbar.nextButtonItem.isEnabled = false
         toolbar.nextButtonItem.title = ""
     }

--- a/Formalist/UITextFieldTextEditorAdapter.swift
+++ b/Formalist/UITextFieldTextEditorAdapter.swift
@@ -129,7 +129,7 @@ private final class TextFieldDelegate<TextFieldType: UITextField>: NSObject, UIT
         switch configuration.returnKeyAction {
         case .none: return true
         case .activateNextResponder:
-            if !(textField.nextFormResponder?.becomeFirstResponder() ?? false) {
+            if !(textField.resolvedNextFormResponder?.becomeFirstResponder() ?? false) {
                 if configuration.shouldResignFirstResponderWhenFinished {
                     textField.resignFirstResponder()
                 }

--- a/Formalist/UITextViewTextEditorAdapter.swift
+++ b/Formalist/UITextViewTextEditorAdapter.swift
@@ -105,7 +105,7 @@ private final class TextViewDelegate<TextViewType: UITextView>: NSObject, UIText
             switch configuration.returnKeyAction {
             case .none: return true
             case .activateNextResponder:
-                if !(textView.nextFormResponder?.becomeFirstResponder() ?? false) {
+                if !(textView.resolvedNextFormResponder?.becomeFirstResponder() ?? false) {
                     if configuration.shouldResignFirstResponderWhenFinished {
                         textView.resignFirstResponder()
                     }


### PR DESCRIPTION
I reverted back to the previous `render()` implementation and then added a private array of responder views that can be grabbed from nested `GroupElement`s.

Here is a link to compare the changes between the last working commit and this new commit to see the actual changes: https://github.com/seedco/Formalist/compare/0.6.0...dm-fix-group-insets?expand=1